### PR TITLE
Reduce state dependencies for `EntryFunc.func_app_start`

### DIFF
--- a/cmd/proto_code/proto_kernel.py
+++ b/cmd/proto_code/proto_kernel.py
@@ -1732,7 +1732,7 @@ def conditional_factory(state_node_class: type[StateNodeSubclass]) -> type[State
     return state_node_class
 
 
-def trivial_factory(state_node_class: type[StateNodeSubclass]) -> type[StateNodeSubclass]:
+def trivial_factory(state_node_class: type[StateNodeSubclass]) -> type[NodeFactory]:
     """
     Class decorator that makes a `StateNode` class act like a factory for itself.
 
@@ -2535,8 +2535,8 @@ class Bootstrapper_state_input_proto_code_file_abs_path_var_loaded(AbstractCachi
 
 
 # noinspection PyPep8Naming
-@trivial_factory
-class Bootstrapper_state_stride_py_arbitrary_reached(AbstractCachingStateNode[StateStride]):
+@conditional_factory
+class Bootstrapper_state_stride_py_arbitrary_reached_is_app(AbstractCachingStateNode[StateStride]):
     """
     Implements UC_90_98_17_93.run_under_venv.md.
     """
@@ -2605,6 +2605,28 @@ class Bootstrapper_state_stride_py_arbitrary_reached(AbstractCachingStateNode[St
             proto_code_abs_file_path=None,
             required_environ=cleaned_env,
         )
+
+
+# noinspection PyPep8Naming
+@conditional_factory
+class Bootstrapper_state_stride_py_arbitrary_reached_not_is_app(AbstractCachingStateNode[StateStride]):
+
+    _state_name = staticmethod(lambda: EnvState.state_stride_py_arbitrary_reached.name)
+
+    def _eval_state_once(self) -> ValueType:
+        # For `func_start_app`: `EnvVar.var_PROTOPRIMER_PROTO_CODE` is set (contract),
+        # so it does not need to switch to `StateStride.stride_py_arbitrary` to set it:
+        return self.env_ctx.set_max_stride(StateStride.stride_py_arbitrary)
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
+# noinspection PyPep8Naming
+class Factory_state_stride_py_arbitrary_reached(NodeFactory[StateStride]):
+
+    def create_state_node(self) -> StateNode[StateStride]:
+        if self.env_ctx._is_app:
+            return Bootstrapper_state_stride_py_arbitrary_reached_is_app(self.env_ctx)
+        else:
+            return Bootstrapper_state_stride_py_arbitrary_reached_not_is_app(self.env_ctx)
 
 
 # noinspection PyPep8Naming
@@ -3711,7 +3733,6 @@ class Bootstrapper_state_stride_py_required_reached_not_command_start(AbstractCa
 
     _parent_states = staticmethod(
         lambda: [
-            EnvState.state_input_sub_command_arg_loaded.name,
             EnvState.state_prepare_venv_finalized.name,
             EnvState.state_input_start_id_var_loaded.name,
             EnvState.state_proto_code_file_abs_path_inited.name,
@@ -3774,7 +3795,6 @@ class Bootstrapper_state_stride_py_required_reached_not_command_start(AbstractCa
 class Bootstrapper_state_stride_py_required_reached_command_start(AbstractCachingStateNode[StateStride]):
     _parent_states = staticmethod(
         lambda: [
-            EnvState.state_input_sub_command_arg_loaded.name,
             EnvState.state_prepare_venv_finalized.name,
             EnvState.state_input_start_id_var_loaded.name,
             EnvState.state_proto_code_file_abs_path_inited.name,
@@ -3788,9 +3808,9 @@ class Bootstrapper_state_stride_py_required_reached_command_start(AbstractCachin
     _state_name = staticmethod(lambda: EnvState.state_stride_py_required_reached.name)
 
     def _eval_state_once(self) -> ValueType:
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
-        state_stride_py_required_reached: StateStride = StateStride.stride_py_required
 
+        state_stride_py_required_reached: StateStride = StateStride.stride_py_required
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
         if self.env_ctx.has_stride_reached(next_stride=state_stride_py_required_reached):
             return self.env_ctx.set_max_stride(state_stride_py_required_reached)
 
@@ -3815,8 +3835,8 @@ class Factory_state_stride_py_required_reached(NodeFactory[StateStride]):
 ########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
 
 # noinspection PyPep8Naming
-@trivial_factory
-class Bootstrapper_state_reboot_triggered(AbstractCachingStateNode[bool]):
+@conditional_factory
+class Bootstrapper_state_reboot_triggered_is_app(AbstractCachingStateNode[bool]):
     """
     Removes current `venv` dir and `version_constraints.txt` file (to trigger their re-creation subsequently).
     """
@@ -3890,8 +3910,28 @@ class Bootstrapper_state_reboot_triggered(AbstractCachingStateNode[bool]):
 
 
 # noinspection PyPep8Naming
-@trivial_factory
-class Bootstrapper_state_venv_driver_prepared(AbstractCachingStateNode[VenvDriverBase]):
+@conditional_factory
+class Bootstrapper_state_reboot_triggered_not_is_app(AbstractCachingStateNode[bool]):
+
+    _state_name = staticmethod(lambda: EnvState.state_reboot_triggered.name)
+
+    def _eval_state_once(self) -> ValueType:
+        return False
+
+
+# noinspection PyPep8Naming
+class Factory_state_reboot_triggered(NodeFactory[bool]):
+
+    def create_state_node(self) -> StateNode[bool]:
+        if self.env_ctx._is_app:
+            return Bootstrapper_state_reboot_triggered_is_app(self.env_ctx)
+        else:
+            return Bootstrapper_state_reboot_triggered_not_is_app(self.env_ctx)
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
+# noinspection PyPep8Naming
+@conditional_factory
+class Bootstrapper_state_venv_driver_prepared_is_app(AbstractCachingStateNode[VenvDriverBase]):
     _parent_states = staticmethod(
         lambda: [
             EnvState.state_input_sub_command_arg_loaded.name,
@@ -3906,15 +3946,9 @@ class Bootstrapper_state_venv_driver_prepared(AbstractCachingStateNode[VenvDrive
     _state_name = staticmethod(lambda: EnvState.state_venv_driver_prepared.name)
 
     def _eval_state_once(self) -> ValueType:
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
         state_input_sub_command_arg_loaded: SubCommand = self.eval_parent_state(EnvState.state_input_sub_command_arg_loaded.name)
-
-        if state_input_sub_command_arg_loaded == SubCommand.command_start:
-            # The only reason for `EnvState.state_venv_driver_prepared`
-            # is to prepare `VenvDriverBase` to create `venv`.
-            # Skip it as `venv` is supposed to be ready in `SubCommand.command_start`:
-            return VenvDriverBase()
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
         state_required_python_version_inited: str = self.eval_parent_state(EnvState.state_required_python_version_inited.name)
 
         state_selected_python_file_abs_path_inited: str = self.eval_parent_state(EnvState.state_selected_python_file_abs_path_inited.name)
@@ -3948,8 +3982,30 @@ class Bootstrapper_state_venv_driver_prepared(AbstractCachingStateNode[VenvDrive
 
 
 # noinspection PyPep8Naming
-@trivial_factory
-class Bootstrapper_state_stride_py_venv_reached(AbstractCachingStateNode[StateStride]):
+@conditional_factory
+class Bootstrapper_state_venv_driver_prepared_not_is_app(AbstractCachingStateNode[VenvDriverBase]):
+    _state_name = staticmethod(lambda: EnvState.state_venv_driver_prepared.name)
+
+    def _eval_state_once(self) -> ValueType:
+        # The only reason for `EnvState.state_venv_driver_prepared`
+        # is to prepare `VenvDriverBase` to create `venv`.
+        # Skip it as `venv` is supposed to be ready in `SubCommand.command_start`:
+        return VenvDriverBase()
+
+
+# noinspection PyPep8Naming
+class Factory_state_venv_driver_prepared(NodeFactory[VenvDriverBase]):
+
+    def create_state_node(self) -> StateNode[VenvDriverBase]:
+        if self.env_ctx._is_app:
+            return Bootstrapper_state_venv_driver_prepared_is_app(self.env_ctx)
+        else:
+            return Bootstrapper_state_venv_driver_prepared_not_is_app(self.env_ctx)
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
+# noinspection PyPep8Naming
+@conditional_factory
+class Bootstrapper_state_stride_py_venv_reached_is_app(AbstractCachingStateNode[StateStride]):
     """
     Creates `venv` and switches to `python` from there.
     """
@@ -3977,19 +4033,13 @@ class Bootstrapper_state_stride_py_venv_reached(AbstractCachingStateNode[StateSt
 
         state_input_sub_command_arg_loaded: SubCommand = self.eval_parent_state(EnvState.state_input_sub_command_arg_loaded.name)
 
-        if state_input_sub_command_arg_loaded == SubCommand.command_start:
-            # The only reason for `EnvState.state_stride_py_venv_reached`
-            # is to create a `venv`.
-            # Skip it as `venv` is supposed to be ready in `SubCommand.command_start`:
-            return self.env_ctx.set_max_stride(state_stride_py_venv_reached)
-
         state_input_start_id_var_loaded: str = self.eval_parent_state(EnvState.state_input_start_id_var_loaded.name)
 
         state_proto_code_file_abs_path_inited: str = self.eval_parent_state(EnvState.state_proto_code_file_abs_path_inited.name)
 
         state_selected_python_file_abs_path_inited: str = self.eval_parent_state(EnvState.state_selected_python_file_abs_path_inited.name)
         state_local_venv_dir_abs_path_inited: str = self.eval_parent_state(EnvState.state_local_venv_dir_abs_path_inited.name)
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
         state_venv_driver_prepared: VenvDriverBase = self.eval_parent_state(EnvState.state_venv_driver_prepared.name)
 
         venv_path_to_python: str = os.path.join(
@@ -3998,12 +4048,16 @@ class Bootstrapper_state_stride_py_venv_reached(AbstractCachingStateNode[StateSt
         )
         path_to_curr_python: str = get_path_to_curr_python()
         logger.debug(f"path_to_curr_python: {path_to_curr_python}")
-
-        if is_sub_path(
-            path_to_curr_python,
-            state_local_venv_dir_abs_path_inited,
-        ):
-            raise AssertionError(f"Current `python` [{path_to_curr_python}] must be outside of the `venv` [{state_local_venv_dir_abs_path_inited}].")
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+        if state_input_sub_command_arg_loaded == SubCommand.command_start:
+            # Skip `venv` validation before switch because `SubCommand.command_start` does not switch outside of `venv`:
+            pass
+        else:
+            if is_sub_path(
+                path_to_curr_python,
+                state_local_venv_dir_abs_path_inited,
+            ):
+                raise AssertionError(f"Current `python` [{path_to_curr_python}] must be outside of the `venv` [{state_local_venv_dir_abs_path_inited}].")
 
         if os.environ.get(EnvVar.var_PROTOPRIMER_MOCKED_RESTART.value, None) is None:
             if state_input_sub_command_arg_loaded == SubCommand.command_start:
@@ -4042,8 +4096,58 @@ class Bootstrapper_state_stride_py_venv_reached(AbstractCachingStateNode[StateSt
 ########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
 
 # noinspection PyPep8Naming
-@trivial_factory
-class Bootstrapper_state_protoprimer_package_installed(AbstractCachingStateNode[bool]):
+@conditional_factory
+class Bootstrapper_state_stride_py_venv_reached_not_is_app(AbstractCachingStateNode[StateStride]):
+
+    _parent_states = staticmethod(
+        lambda: [
+            EnvState.state_input_start_id_var_loaded.name,
+            EnvState.state_proto_code_file_abs_path_inited.name,
+            EnvState.state_local_venv_dir_abs_path_inited.name,
+        ]
+    )
+    _state_name = staticmethod(lambda: EnvState.state_stride_py_venv_reached.name)
+
+    def _eval_state_once(self) -> ValueType:
+        state_stride: StateStride = StateStride.stride_py_venv
+
+        if self.env_ctx.has_stride_reached(next_stride=state_stride):
+            return self.env_ctx.set_max_stride(state_stride)
+
+        state_input_start_id_var_loaded: str = self.eval_parent_state(EnvState.state_input_start_id_var_loaded.name)
+        state_proto_code_file_abs_path_inited: str = self.eval_parent_state(EnvState.state_proto_code_file_abs_path_inited.name)
+        state_local_venv_dir_abs_path_inited: str = self.eval_parent_state(EnvState.state_local_venv_dir_abs_path_inited.name)
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+        # The `venv` is supposed to be ready when called as `func_start_app`:
+        if not os.path.exists(state_local_venv_dir_abs_path_inited):
+            raise AssertionError(f"`venv` [{state_local_venv_dir_abs_path_inited}] is not found, run `{SubCommand.command_boot.value}` first")
+
+        venv_path_to_python: str = os.path.join(
+            state_local_venv_dir_abs_path_inited,
+            ConfConstGeneral.file_rel_path_venv_python,
+        )
+        return switch_python(
+            curr_python_path=get_path_to_curr_python(),
+            next_py_exec=self.env_ctx.set_max_stride(state_stride),
+            next_python_path=venv_path_to_python,
+            start_id=state_input_start_id_var_loaded,
+            proto_code_abs_file_path=state_proto_code_file_abs_path_inited,
+        )
+
+
+# noinspection PyPep8Naming
+class Factory_state_stride_py_venv_reached(NodeFactory[StateStride]):
+
+    def create_state_node(self) -> StateNode[StateStride]:
+        if self.env_ctx._is_app:
+            return Bootstrapper_state_stride_py_venv_reached_is_app(self.env_ctx)
+        else:
+            return Bootstrapper_state_stride_py_venv_reached_not_is_app(self.env_ctx)
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
+# noinspection PyPep8Naming
+@conditional_factory
+class Bootstrapper_state_protoprimer_package_installed_is_app(AbstractCachingStateNode[bool]):
 
     _parent_states = staticmethod(
         lambda: [
@@ -4063,6 +4167,9 @@ class Bootstrapper_state_protoprimer_package_installed(AbstractCachingStateNode[
 ########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
         state_input_sub_command_arg_loaded: SubCommand = self.eval_parent_state(EnvState.state_input_sub_command_arg_loaded.name)
 
+        # TODO: FT_77_15_06_50.dynamic_DAG.md:
+        #       This is not reachable for `SubCommand.command_start`.
+        #       Command `command_start` will switch to `venv_module:func_name` at `StateStride.stride_py_venv`:
         if state_input_sub_command_arg_loaded == SubCommand.command_start:
             # The only reason for `EnvState.state_protoprimer_package_installed`
             # is to install dependencies into `venv`.
@@ -4079,9 +4186,9 @@ class Bootstrapper_state_protoprimer_package_installed(AbstractCachingStateNode[
         state_project_descriptors_inited: list[dict] = self.eval_parent_state(EnvState.state_project_descriptors_inited.name)
 
         state_install_specs_inited: list[dict] = self.eval_parent_state(EnvState.state_install_specs_inited.name)
-
-        state_venv_driver_prepared: VenvDriverBase = self.eval_parent_state(EnvState.state_venv_driver_prepared.name)
 ########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+        state_venv_driver_prepared: VenvDriverBase = self.eval_parent_state(EnvState.state_venv_driver_prepared.name)
+
         state_version_constraints_file_basename_inited: str = self.eval_parent_state(EnvState.state_version_constraints_file_basename_inited.name)
 
         install_packages: bool = state_stride_py_venv_reached.value == StateStride.stride_py_venv.value
@@ -4173,8 +4280,28 @@ class Bootstrapper_state_protoprimer_package_installed(AbstractCachingStateNode[
 
 
 # noinspection PyPep8Naming
-@trivial_factory
-class Bootstrapper_state_version_constraints_generated(AbstractCachingStateNode[bool]):
+@conditional_factory
+class Bootstrapper_state_protoprimer_package_installed_not_is_app(AbstractCachingStateNode[bool]):
+
+    _state_name = staticmethod(lambda: EnvState.state_protoprimer_package_installed.name)
+
+    def _eval_state_once(self) -> ValueType:
+        return False
+
+
+# noinspection PyPep8Naming
+class Factory_state_protoprimer_package_installed(NodeFactory[bool]):
+
+    def create_state_node(self) -> StateNode[bool]:
+        if self.env_ctx._is_app:
+            return Bootstrapper_state_protoprimer_package_installed_is_app(self.env_ctx)
+        else:
+            return Bootstrapper_state_protoprimer_package_installed_not_is_app(self.env_ctx)
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
+# noinspection PyPep8Naming
+@conditional_factory
+class Bootstrapper_state_version_constraints_generated_is_app(AbstractCachingStateNode[bool]):
     """
     Implements UC_44_82_07_30.requirements_lock.md.
     """
@@ -4189,11 +4316,14 @@ class Bootstrapper_state_version_constraints_generated(AbstractCachingStateNode[
         ]
     )
     _state_name = staticmethod(lambda: EnvState.state_version_constraints_generated.name)
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
-    def _eval_state_once(self) -> ValueType:
 
+    def _eval_state_once(self) -> ValueType:
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
         state_input_sub_command_arg_loaded: SubCommand = self.eval_parent_state(EnvState.state_input_sub_command_arg_loaded.name)
 
+        # TODO: FT_77_15_06_50.dynamic_DAG.md:
+        #       This is not reachable for `SubCommand.command_start`.
+        #       Command `command_start` will switch to `venv_module:func_name` at `StateStride.stride_py_venv`:
         if state_input_sub_command_arg_loaded == SubCommand.command_start:
             # The only reason for `EnvState.state_version_constraints_generated`
             # is to re-generate the `version_constraints.txt` file based on `venv`.
@@ -4223,8 +4353,28 @@ class Bootstrapper_state_version_constraints_generated(AbstractCachingStateNode[
 
 
 # noinspection PyPep8Naming
-@trivial_factory
-class Bootstrapper_state_stride_deps_updated_reached(AbstractCachingStateNode[StateStride]):
+@conditional_factory
+class Bootstrapper_state_version_constraints_generated_not_is_app(AbstractCachingStateNode[bool]):
+
+    _state_name = staticmethod(lambda: EnvState.state_version_constraints_generated.name)
+
+    def _eval_state_once(self) -> ValueType:
+        return False
+
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+# noinspection PyPep8Naming
+class Factory_state_version_constraints_generated(NodeFactory[bool]):
+
+    def create_state_node(self) -> StateNode[bool]:
+        if self.env_ctx._is_app:
+            return Bootstrapper_state_version_constraints_generated_is_app(self.env_ctx)
+        else:
+            return Bootstrapper_state_version_constraints_generated_not_is_app(self.env_ctx)
+
+
+# noinspection PyPep8Naming
+@conditional_factory
+class Bootstrapper_state_stride_deps_updated_reached_is_app(AbstractCachingStateNode[StateStride]):
 
     _parent_states = staticmethod(
         lambda: [
@@ -4246,6 +4396,9 @@ class Bootstrapper_state_stride_deps_updated_reached(AbstractCachingStateNode[St
 
         state_input_sub_command_arg_loaded: SubCommand = self.eval_parent_state(EnvState.state_input_sub_command_arg_loaded.name)
 
+        # TODO: FT_77_15_06_50.dynamic_DAG.md:
+        #       This is not reachable for `SubCommand.command_start`.
+        #       Command `command_start` will switch to `venv_module:func_name` at `StateStride.stride_py_venv`:
         if state_input_sub_command_arg_loaded == SubCommand.command_start:
             # The only reason for `EnvState.state_stride_deps_updated_reached`
             # is to make `venv` dependencies effective.
@@ -4255,12 +4408,12 @@ class Bootstrapper_state_stride_deps_updated_reached(AbstractCachingStateNode[St
         state_proto_code_file_abs_path_inited: str = self.eval_parent_state(EnvState.state_proto_code_file_abs_path_inited.name)
 
         state_local_venv_dir_abs_path_inited: str = self.eval_parent_state(EnvState.state_local_venv_dir_abs_path_inited.name)
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
         venv_path_to_python: str = os.path.join(
             state_local_venv_dir_abs_path_inited,
             ConfConstGeneral.file_rel_path_venv_python,
         )
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
         state_input_start_id_var_loaded: str = self.eval_parent_state(EnvState.state_input_start_id_var_loaded.name)
 
         return switch_python(
@@ -4273,14 +4426,34 @@ class Bootstrapper_state_stride_deps_updated_reached(AbstractCachingStateNode[St
 
 
 # noinspection PyPep8Naming
-@trivial_factory
-class Bootstrapper_state_proto_code_updated(AbstractCachingStateNode[bool]):
+@conditional_factory
+class Bootstrapper_state_stride_deps_updated_reached_not_is_app(AbstractCachingStateNode[StateStride]):
+
+    _state_name = staticmethod(lambda: EnvState.state_stride_deps_updated_reached.name)
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+    def _eval_state_once(self) -> ValueType:
+        return self.env_ctx.set_max_stride(StateStride.stride_deps_updated)
+
+
+# noinspection PyPep8Naming
+class Factory_state_stride_deps_updated_reached(NodeFactory[StateStride]):
+
+    def create_state_node(self) -> StateNode[StateStride]:
+        if self.env_ctx._is_app:
+            return Bootstrapper_state_stride_deps_updated_reached_is_app(self.env_ctx)
+        else:
+            return Bootstrapper_state_stride_deps_updated_reached_not_is_app(self.env_ctx)
+
+
+# noinspection PyPep8Naming
+@conditional_factory
+class Bootstrapper_state_proto_code_updated_is_app(AbstractCachingStateNode[bool]):
     """
     Return `True` if content of the `proto_kernel` has changed.
 
     TODO: UC_52_87_82_92.conditional_auto_update.md
     """
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
     _parent_states = staticmethod(
         lambda: [
             EnvState.state_input_sub_command_arg_loaded.name,
@@ -4289,7 +4462,7 @@ class Bootstrapper_state_proto_code_updated(AbstractCachingStateNode[bool]):
         ]
     )
     _state_name = staticmethod(lambda: EnvState.state_proto_code_updated.name)
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
     def _eval_state_once(self) -> ValueType:
 
         assert self.env_ctx.get_stride().value >= StateStride.stride_deps_updated.value
@@ -4300,17 +4473,20 @@ class Bootstrapper_state_proto_code_updated(AbstractCachingStateNode[bool]):
 
         state_input_sub_command_arg_loaded: SubCommand = self.eval_parent_state(EnvState.state_input_sub_command_arg_loaded.name)
 
+        # TODO: FT_77_15_06_50.dynamic_DAG.md:
+        #       This is not reachable for `SubCommand.command_start`.
+        #       Command `command_start` will switch to `venv_module:func_name` at `StateStride.stride_py_venv`:
         if state_input_sub_command_arg_loaded == SubCommand.command_start:
             # The only reason for `EnvState.state_proto_code_updated`
             # is to update sources, but that has to be done in `SubCommand.command_boot`.
             # Skip:
             return False
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
         state_proto_code_file_abs_path_inited = self.eval_parent_state(EnvState.state_proto_code_file_abs_path_inited.name)
         assert os.path.isabs(state_proto_code_file_abs_path_inited)
         assert not os.path.islink(state_proto_code_file_abs_path_inited)
         assert os.path.isfile(state_proto_code_file_abs_path_inited)
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
         assert is_venv()
         try:
             import protoprimer
@@ -4329,12 +4505,12 @@ class Bootstrapper_state_proto_code_updated(AbstractCachingStateNode[bool]):
         # generated code inside generated code inside generated code ...
         generated_content_single_header: str = protoprimer.primer_kernel.ConfConstGeneral.func_get_proto_code_generated_boilerplate_single_header(protoprimer.primer_kernel)
         generated_content_multiple_body: str = protoprimer.primer_kernel.ConfConstGeneral.func_get_proto_code_generated_boilerplate_multiple_body(protoprimer.primer_kernel)
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
         # Use `primer_kernel` from installed package as the source for `proto_code` update:
         primer_kernel_abs_path = os.path.abspath(str(protoprimer.primer_kernel.__file__))
         primer_kernel_text: str = read_text_file(primer_kernel_abs_path)
         proto_code_text_old: str = read_text_file(state_proto_code_file_abs_path_inited)
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
         # Update body:
         proto_code_text_with_body = _replace_multiple_body_in_empty_lines(
             input_text=primer_kernel_text,
@@ -4353,9 +4529,29 @@ class Bootstrapper_state_proto_code_updated(AbstractCachingStateNode[bool]):
             file_path=state_proto_code_file_abs_path_inited,
             file_data=proto_code_text_new,
         )
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
         is_updated: bool = proto_code_text_old != proto_code_text_new
         return is_updated
+
+
+# noinspection PyPep8Naming
+@conditional_factory
+class Bootstrapper_state_proto_code_updated_not_is_app(AbstractCachingStateNode[bool]):
+
+    _state_name = staticmethod(lambda: EnvState.state_proto_code_updated.name)
+
+    def _eval_state_once(self) -> ValueType:
+        return False
+
+
+# noinspection PyPep8Naming
+class Factory_state_proto_code_updated(NodeFactory[bool]):
+
+    def create_state_node(self) -> StateNode[bool]:
+        if self.env_ctx._is_app:
+            return Bootstrapper_state_proto_code_updated_is_app(self.env_ctx)
+        else:
+            return Bootstrapper_state_proto_code_updated_not_is_app(self.env_ctx)
 ########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
 
 # noinspection PyPep8Naming
@@ -4364,7 +4560,6 @@ class Bootstrapper_state_stride_src_updated_reached(AbstractCachingStateNode[Sta
 
     _parent_states = staticmethod(
         lambda: [
-            EnvState.state_input_sub_command_arg_loaded.name,
             EnvState.state_input_start_id_var_loaded.name,
             EnvState.state_proto_code_file_abs_path_inited.name,
             EnvState.state_local_venv_dir_abs_path_inited.name,
@@ -4534,7 +4729,7 @@ class EnvState(enum.Enum):
     state_input_proto_code_file_abs_path_var_loaded = Bootstrapper_state_input_proto_code_file_abs_path_var_loaded
 
     # restart: `StateStride.stride_py_unknown` -> `StateStride.stride_py_arbitrary`:
-    state_stride_py_arbitrary_reached = Bootstrapper_state_stride_py_arbitrary_reached
+    state_stride_py_arbitrary_reached = Factory_state_stride_py_arbitrary_reached
 
     state_proto_code_file_abs_path_inited = Factory_state_proto_code_file_abs_path_inited
 
@@ -4598,24 +4793,23 @@ class EnvState(enum.Enum):
     # restart: `StateStride.stride_py_arbitrary` -> `StateStride.stride_py_required`:
     state_stride_py_required_reached = Factory_state_stride_py_required_reached
 
-    state_reboot_triggered = Bootstrapper_state_reboot_triggered
+    state_reboot_triggered = Factory_state_reboot_triggered
 
-    state_venv_driver_prepared = Bootstrapper_state_venv_driver_prepared
+    state_venv_driver_prepared = Factory_state_venv_driver_prepared
 
     # restart: `StateStride.stride_py_required` -> `StateStride.stride_py_venv`:
-    state_stride_py_venv_reached = Bootstrapper_state_stride_py_venv_reached
+    state_stride_py_venv_reached = Factory_state_stride_py_venv_reached
 ########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
-    # TODO: rename to "client" (or "ref"?): `client_project_descriptors_installed`:
-    state_protoprimer_package_installed = Bootstrapper_state_protoprimer_package_installed
+    state_protoprimer_package_installed = Factory_state_protoprimer_package_installed
 
-    state_version_constraints_generated = Bootstrapper_state_version_constraints_generated
+    state_version_constraints_generated = Factory_state_version_constraints_generated
 
     # restart: `StateStride.stride_py_venv` -> `StateStride.stride_deps_updated`:
     # TODO: rename - "reached" sounds weird (and makes no sense):
-    state_stride_deps_updated_reached = Bootstrapper_state_stride_deps_updated_reached
+    state_stride_deps_updated_reached = Factory_state_stride_deps_updated_reached
 
     # TODO: rename according to the final name:
-    state_proto_code_updated = Bootstrapper_state_proto_code_updated
+    state_proto_code_updated = Factory_state_proto_code_updated
 
     # restart: `StateStride.stride_deps_updated` -> `StateStride.stride_src_updated`:
     state_stride_src_updated_reached = Bootstrapper_state_stride_src_updated_reached
@@ -4638,9 +4832,7 @@ class TargetState(enum.Enum):
     target_derived_config_loaded = EnvState.state_derived_conf_data_loaded
 
     # # FT_05_08_64_67.start_app.md
-    # TODO: FT_77_15_06_50.dynamic_DAG.md:
-    #       Can For `StateStride.stride_py_venv` be enough for `EntryFunc.func_start_app`?
-    target_venv_activated = EnvState.state_stride_src_updated_reached
+    target_venv_activated = EnvState.state_stride_py_venv_reached
 
     # FT_85_17_35_21.boot_env.md
     # The final state before switching to `PrimerRuntime.runtime_meta`:
@@ -4651,11 +4843,11 @@ class StateGraph:
     """
     It is a graph, which must be a DAG.
     """
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
     def __init__(self):
         self.state_nodes: dict[str, StateNode] = {}
         self.state_factories: dict[str, NodeFactory] = {}
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
     def register_factory(
         self,
         state_name: str,
@@ -4849,35 +5041,35 @@ class ContextBuilder:
     def __init__(self):
         self._env_ctx = EnvContext()
 
-    def entry_func(self, value: EntryFunc) -> "ContextBuilder":
+    def entry_func(self, value: EntryFunc) -> ContextBuilder:
         self._env_ctx._entry_func = value
         return self
 ########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
-    def state_stride(self, value: StateStride) -> "ContextBuilder":
+    def state_stride(self, value: StateStride) -> ContextBuilder:
         self._env_ctx._state_stride = value
         return self
 
-    def is_app(self, value: bool) -> "ContextBuilder":
+    def is_app(self, value: bool) -> ContextBuilder:
         self._env_ctx._is_app = value
         return self
 
-    def prepare_venv(self, value: bool) -> "ContextBuilder":
+    def prepare_venv(self, value: bool) -> ContextBuilder:
         self._env_ctx._prepare_venv = value
         return self
 
-    def sub_command(self, value: SubCommand) -> "ContextBuilder":
+    def sub_command(self, value: SubCommand) -> ContextBuilder:
         self._env_ctx._sub_command = value
         return self
 
-    def is_log_enabled(self, value: bool) -> "ContextBuilder":
+    def is_log_enabled(self, value: bool) -> ContextBuilder:
         self._env_ctx._is_log_enabled = value
         return self
 
-    def final_state(self, value: str) -> "ContextBuilder":
+    def final_state(self, value: str) -> ContextBuilder:
         self._env_ctx._final_state = value
         return self
 ########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
-    def proto_kernel_abs_path(self, value: str) -> "ContextBuilder":
+    def proto_kernel_abs_path(self, value: str) -> ContextBuilder:
         self._env_ctx._proto_kernel_abs_path = value
         return self
 
@@ -5335,7 +5527,7 @@ def get_path_to_base_python() -> str:
 
     executable_basename: str = os.path.basename(sys.executable)
 
-    # Try current `executable_basename` first.
+    # Try the current `executable_basename` first.
     # In some cases (e.g. on `macOS` with `homebrew`),
     # there are no simple basenames like `python`, instead, there are versioned ones like `python3.10`:
     path_to_next_python: str = os.path.join(
@@ -5803,18 +5995,11 @@ def _start_main(
     installed_kernel_name = f"{ConfConstGeneral.name_protoprimer_package}.{ConfConstGeneral.name_primer_kernel_module}"
 ########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
     try:
-        # NOTE: `state_stride_src_updated_reached` forces restart with this `StateStride`:
         if curr_py_exec.value >= StateStride.stride_src_updated.value:
+            # FT_74_10_40_33.DAG_extension.md:
+            # Complete `EntryFunc.func_boot_env` with extension (if any).
             venv_module = importlib.import_module(module_name)
             selected_main = getattr(venv_module, func_name)
-            if entry_func == EntryFunc.func_start_app:
-                # TODO: FT_77_15_06_50.dynamic_DAG.md:
-                #       Can For `StateStride.stride_py_venv` be enough for `EntryFunc.func_start_app`?
-                # FT_96_50_58_75.context_propagation.md:
-                # Switch from running `proto_code` to installed `venv` code:
-                imported_kernel = importlib.import_module(installed_kernel_name)
-                setattr(imported_kernel, "_proto_kernel_abs_path", os.environ[EnvVar.var_PROTOPRIMER_PROTO_CODE.value])
-                remove_protoprimer_env_vars(os.environ)
             selected_main()
         elif curr_py_exec.value >= StateStride.stride_deps_updated.value:
             # TODO: FT_21_75_54_18.instant_scenario.md:
@@ -5830,27 +6015,43 @@ def _start_main(
             env_ctx = imported_EnvContext()
             env_ctx._entry_func = imported_EntryFunc[entry_func.name]
             imported_run_process(env_ctx)
+        elif curr_py_exec.value >= StateStride.stride_py_venv.value and entry_func == EntryFunc.func_start_app:
+            venv_module = importlib.import_module(module_name)
+            selected_main = getattr(venv_module, func_name)
+            # FT_96_50_58_75.context_propagation.md:
+            # Switch from running `proto_code` to installed `venv` code:
+            imported_kernel = importlib.import_module(installed_kernel_name)
+            setattr(imported_kernel, "_proto_kernel_abs_path", os.environ[EnvVar.var_PROTOPRIMER_PROTO_CODE.value])
+            remove_protoprimer_env_vars(os.environ)
+            selected_main()
         else:
+            # FT_14_52_73_23.primer_runtime.md:
+            # Keep running `proto_code`:
             env_ctx = EnvContext()
             env_ctx._entry_func = entry_func
             run_process(env_ctx)
-    except ImportError as e:
-        if curr_py_exec.value >= StateStride.stride_src_updated.value:
-            raise AssertionError(
-                f"Failed to import `{module_name}` with `{EnvVar.var_PROTOPRIMER_PY_EXEC.value}` [{curr_py_exec.name}]. "
-                # TODO: This hint is only correct for error to import anything from `protoprimer`,
-                #       not any import in general:
-                f"{get_import_error_hint(module_name)} "
 ########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
-            )
-        raise e
+    except ImportError as import_error:
+        if curr_py_exec.value >= StateStride.stride_py_venv.value and entry_func == EntryFunc.func_start_app:
+            raise AssertionError(
+                f"Failed to import `{import_error.name}` at [{curr_py_exec.name}]. "
+                f"Has `{KeyWord.key_venv.value}` been initialized via `{SubCommand.command_boot.value}` sub command? "
+                #
+            ) from import_error
+        if import_error.name == installed_kernel_name:
+            raise AssertionError(
+                f"Failed to import `{installed_kernel_name}` at [{curr_py_exec.name}]. "
+                f"{get_import_error_hint(installed_kernel_name)} "
+                #
+            ) from import_error
+        raise import_error
 
 
 def _proto_main() -> None:
     env_ctx = EnvContext()
     env_ctx._entry_func = EntryFunc.func_run_main
     run_process(env_ctx)
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
 
 if __name__ == "__main__":
     _proto_main()

--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -58,6 +58,24 @@ section#why details > summary {
     margin-top: 1em;
 }
 
+/* Narrow viewport: match sidebar background to main content */
+@media screen and (max-width: 1200px) {
+    div.sphinxsidebar {
+        background: #fff !important;
+        color: #000 !important;
+    }
+    div.sphinxsidebar ul, div.sphinxsidebar ol {
+        padding-left: 0 !important;
+    }
+    div.sphinxsidebar h3, div.sphinxsidebar h4, div.sphinxsidebar p,
+    div.sphinxsidebar h3 a {
+        color: #444 !important;
+    }
+    div.sphinxsidebar a {
+        color: #444 !important;
+    }
+}
+
 /* RTD ads shown in footer via #ethical-ads-placement, hide sidebar fallback */
 .sphinxsidebar #ethical-ads-placement,
 .sphinxsidebar [data-ea-publisher] {

--- a/dst/default_env/version_constraints.txt
+++ b/dst/default_env/version_constraints.txt
@@ -8,7 +8,7 @@ cfgv==3.5.0
 charset-normalizer==3.4.7
 cliff==4.14.0
 cmd2==3.5.1
-coverage==7.14.0
+coverage==7.14.1
 cryptography==48.0.0
 distlib==0.4.0
 docutils==0.22.4
@@ -16,7 +16,7 @@ filelock==3.29.0
 freezegun==1.5.5
 google-auth==2.53.0
 identify==2.6.19
-idna==3.16
+idna==3.17
 imagesize==2.0.0
 iniconfig==2.3.0
 jaraco-classes==3.4.0
@@ -34,8 +34,8 @@ more-itertools==11.1.0
 myst-parser==5.1.0
 nodeenv==1.10.0
 packaging==26.2
-pip==26.1.1
-platformdirs==4.9.6
+pip==26.1.2
+platformdirs==4.10.0
 pluggy==1.6.0
 pre-commit==4.6.0
 prettytable==3.17.0
@@ -48,7 +48,7 @@ pyperclip==1.11.0
 pytest==9.0.3
 pytest-mock==3.15.1
 python-dateutil==2.9.0.post0
-python-discovery==1.3.1
+python-discovery==1.4.0
 pyyaml==6.0.3
 requests==2.34.2
 rich==15.0.0
@@ -57,8 +57,8 @@ roman-numerals==4.1.0
 secretstorage==3.5.0
 setuptools==82.0.1
 six==1.17.0
-snowballstemmer==3.0.1
-soupsieve==2.8.3
+snowballstemmer==3.1.0
+soupsieve==2.8.4
 sphinx==9.1.0
 sphinx-rtd-theme==3.1.0
 sphinxcontrib-applehelp==2.0.0
@@ -75,5 +75,5 @@ tomli==2.4.1
 tomli-w==1.2.0
 typing-extensions==4.15.0
 urllib3==2.7.0
-virtualenv==21.3.3
+virtualenv==21.4.2
 wcwidth==0.7.0

--- a/src/protoprimer/main/protoprimer/primer_kernel.py
+++ b/src/protoprimer/main/protoprimer/primer_kernel.py
@@ -1732,7 +1732,7 @@ def conditional_factory(state_node_class: type[StateNodeSubclass]) -> type[State
     return state_node_class
 
 
-def trivial_factory(state_node_class: type[StateNodeSubclass]) -> type[StateNodeSubclass]:
+def trivial_factory(state_node_class: type[StateNodeSubclass]) -> type[NodeFactory]:
     """
     Class decorator that makes a `StateNode` class act like a factory for itself.
 
@@ -2535,8 +2535,8 @@ class Bootstrapper_state_input_proto_code_file_abs_path_var_loaded(AbstractCachi
 
 
 # noinspection PyPep8Naming
-@trivial_factory
-class Bootstrapper_state_stride_py_arbitrary_reached(AbstractCachingStateNode[StateStride]):
+@conditional_factory
+class Bootstrapper_state_stride_py_arbitrary_reached_is_app(AbstractCachingStateNode[StateStride]):
     """
     Implements UC_90_98_17_93.run_under_venv.md.
     """
@@ -2605,6 +2605,28 @@ class Bootstrapper_state_stride_py_arbitrary_reached(AbstractCachingStateNode[St
             proto_code_abs_file_path=None,
             required_environ=cleaned_env,
         )
+
+
+# noinspection PyPep8Naming
+@conditional_factory
+class Bootstrapper_state_stride_py_arbitrary_reached_not_is_app(AbstractCachingStateNode[StateStride]):
+
+    _state_name = staticmethod(lambda: EnvState.state_stride_py_arbitrary_reached.name)
+
+    def _eval_state_once(self) -> ValueType:
+        # For `func_start_app`: `EnvVar.var_PROTOPRIMER_PROTO_CODE` is set (contract),
+        # so it does not need to switch to `StateStride.stride_py_arbitrary` to set it:
+        return self.env_ctx.set_max_stride(StateStride.stride_py_arbitrary)
+
+
+# noinspection PyPep8Naming
+class Factory_state_stride_py_arbitrary_reached(NodeFactory[StateStride]):
+
+    def create_state_node(self) -> StateNode[StateStride]:
+        if self.env_ctx._is_app:
+            return Bootstrapper_state_stride_py_arbitrary_reached_is_app(self.env_ctx)
+        else:
+            return Bootstrapper_state_stride_py_arbitrary_reached_not_is_app(self.env_ctx)
 
 
 # noinspection PyPep8Naming
@@ -3711,7 +3733,6 @@ class Bootstrapper_state_stride_py_required_reached_not_command_start(AbstractCa
 
     _parent_states = staticmethod(
         lambda: [
-            EnvState.state_input_sub_command_arg_loaded.name,
             EnvState.state_prepare_venv_finalized.name,
             EnvState.state_input_start_id_var_loaded.name,
             EnvState.state_proto_code_file_abs_path_inited.name,
@@ -3774,7 +3795,6 @@ class Bootstrapper_state_stride_py_required_reached_not_command_start(AbstractCa
 class Bootstrapper_state_stride_py_required_reached_command_start(AbstractCachingStateNode[StateStride]):
     _parent_states = staticmethod(
         lambda: [
-            EnvState.state_input_sub_command_arg_loaded.name,
             EnvState.state_prepare_venv_finalized.name,
             EnvState.state_input_start_id_var_loaded.name,
             EnvState.state_proto_code_file_abs_path_inited.name,
@@ -3815,8 +3835,8 @@ class Factory_state_stride_py_required_reached(NodeFactory[StateStride]):
 
 
 # noinspection PyPep8Naming
-@trivial_factory
-class Bootstrapper_state_reboot_triggered(AbstractCachingStateNode[bool]):
+@conditional_factory
+class Bootstrapper_state_reboot_triggered_is_app(AbstractCachingStateNode[bool]):
     """
     Removes current `venv` dir and `version_constraints.txt` file (to trigger their re-creation subsequently).
     """
@@ -3890,8 +3910,28 @@ class Bootstrapper_state_reboot_triggered(AbstractCachingStateNode[bool]):
 
 
 # noinspection PyPep8Naming
-@trivial_factory
-class Bootstrapper_state_venv_driver_prepared(AbstractCachingStateNode[VenvDriverBase]):
+@conditional_factory
+class Bootstrapper_state_reboot_triggered_not_is_app(AbstractCachingStateNode[bool]):
+
+    _state_name = staticmethod(lambda: EnvState.state_reboot_triggered.name)
+
+    def _eval_state_once(self) -> ValueType:
+        return False
+
+
+# noinspection PyPep8Naming
+class Factory_state_reboot_triggered(NodeFactory[bool]):
+
+    def create_state_node(self) -> StateNode[bool]:
+        if self.env_ctx._is_app:
+            return Bootstrapper_state_reboot_triggered_is_app(self.env_ctx)
+        else:
+            return Bootstrapper_state_reboot_triggered_not_is_app(self.env_ctx)
+
+
+# noinspection PyPep8Naming
+@conditional_factory
+class Bootstrapper_state_venv_driver_prepared_is_app(AbstractCachingStateNode[VenvDriverBase]):
     _parent_states = staticmethod(
         lambda: [
             EnvState.state_input_sub_command_arg_loaded.name,
@@ -3908,12 +3948,6 @@ class Bootstrapper_state_venv_driver_prepared(AbstractCachingStateNode[VenvDrive
     def _eval_state_once(self) -> ValueType:
 
         state_input_sub_command_arg_loaded: SubCommand = self.eval_parent_state(EnvState.state_input_sub_command_arg_loaded.name)
-
-        if state_input_sub_command_arg_loaded == SubCommand.command_start:
-            # The only reason for `EnvState.state_venv_driver_prepared`
-            # is to prepare `VenvDriverBase` to create `venv`.
-            # Skip it as `venv` is supposed to be ready in `SubCommand.command_start`:
-            return VenvDriverBase()
 
         state_required_python_version_inited: str = self.eval_parent_state(EnvState.state_required_python_version_inited.name)
 
@@ -3948,8 +3982,30 @@ class Bootstrapper_state_venv_driver_prepared(AbstractCachingStateNode[VenvDrive
 
 
 # noinspection PyPep8Naming
-@trivial_factory
-class Bootstrapper_state_stride_py_venv_reached(AbstractCachingStateNode[StateStride]):
+@conditional_factory
+class Bootstrapper_state_venv_driver_prepared_not_is_app(AbstractCachingStateNode[VenvDriverBase]):
+    _state_name = staticmethod(lambda: EnvState.state_venv_driver_prepared.name)
+
+    def _eval_state_once(self) -> ValueType:
+        # The only reason for `EnvState.state_venv_driver_prepared`
+        # is to prepare `VenvDriverBase` to create `venv`.
+        # Skip it as `venv` is supposed to be ready in `SubCommand.command_start`:
+        return VenvDriverBase()
+
+
+# noinspection PyPep8Naming
+class Factory_state_venv_driver_prepared(NodeFactory[VenvDriverBase]):
+
+    def create_state_node(self) -> StateNode[VenvDriverBase]:
+        if self.env_ctx._is_app:
+            return Bootstrapper_state_venv_driver_prepared_is_app(self.env_ctx)
+        else:
+            return Bootstrapper_state_venv_driver_prepared_not_is_app(self.env_ctx)
+
+
+# noinspection PyPep8Naming
+@conditional_factory
+class Bootstrapper_state_stride_py_venv_reached_is_app(AbstractCachingStateNode[StateStride]):
     """
     Creates `venv` and switches to `python` from there.
     """
@@ -3977,12 +4033,6 @@ class Bootstrapper_state_stride_py_venv_reached(AbstractCachingStateNode[StateSt
 
         state_input_sub_command_arg_loaded: SubCommand = self.eval_parent_state(EnvState.state_input_sub_command_arg_loaded.name)
 
-        if state_input_sub_command_arg_loaded == SubCommand.command_start:
-            # The only reason for `EnvState.state_stride_py_venv_reached`
-            # is to create a `venv`.
-            # Skip it as `venv` is supposed to be ready in `SubCommand.command_start`:
-            return self.env_ctx.set_max_stride(state_stride_py_venv_reached)
-
         state_input_start_id_var_loaded: str = self.eval_parent_state(EnvState.state_input_start_id_var_loaded.name)
 
         state_proto_code_file_abs_path_inited: str = self.eval_parent_state(EnvState.state_proto_code_file_abs_path_inited.name)
@@ -3999,11 +4049,15 @@ class Bootstrapper_state_stride_py_venv_reached(AbstractCachingStateNode[StateSt
         path_to_curr_python: str = get_path_to_curr_python()
         logger.debug(f"path_to_curr_python: {path_to_curr_python}")
 
-        if is_sub_path(
-            path_to_curr_python,
-            state_local_venv_dir_abs_path_inited,
-        ):
-            raise AssertionError(f"Current `python` [{path_to_curr_python}] must be outside of the `venv` [{state_local_venv_dir_abs_path_inited}].")
+        if state_input_sub_command_arg_loaded == SubCommand.command_start:
+            # Skip `venv` validation before switch because `SubCommand.command_start` does not switch outside of `venv`:
+            pass
+        else:
+            if is_sub_path(
+                path_to_curr_python,
+                state_local_venv_dir_abs_path_inited,
+            ):
+                raise AssertionError(f"Current `python` [{path_to_curr_python}] must be outside of the `venv` [{state_local_venv_dir_abs_path_inited}].")
 
         if os.environ.get(EnvVar.var_PROTOPRIMER_MOCKED_RESTART.value, None) is None:
             if state_input_sub_command_arg_loaded == SubCommand.command_start:
@@ -4042,8 +4096,58 @@ class Bootstrapper_state_stride_py_venv_reached(AbstractCachingStateNode[StateSt
 
 
 # noinspection PyPep8Naming
-@trivial_factory
-class Bootstrapper_state_protoprimer_package_installed(AbstractCachingStateNode[bool]):
+@conditional_factory
+class Bootstrapper_state_stride_py_venv_reached_not_is_app(AbstractCachingStateNode[StateStride]):
+
+    _parent_states = staticmethod(
+        lambda: [
+            EnvState.state_input_start_id_var_loaded.name,
+            EnvState.state_proto_code_file_abs_path_inited.name,
+            EnvState.state_local_venv_dir_abs_path_inited.name,
+        ]
+    )
+    _state_name = staticmethod(lambda: EnvState.state_stride_py_venv_reached.name)
+
+    def _eval_state_once(self) -> ValueType:
+        state_stride: StateStride = StateStride.stride_py_venv
+
+        if self.env_ctx.has_stride_reached(next_stride=state_stride):
+            return self.env_ctx.set_max_stride(state_stride)
+
+        state_input_start_id_var_loaded: str = self.eval_parent_state(EnvState.state_input_start_id_var_loaded.name)
+        state_proto_code_file_abs_path_inited: str = self.eval_parent_state(EnvState.state_proto_code_file_abs_path_inited.name)
+        state_local_venv_dir_abs_path_inited: str = self.eval_parent_state(EnvState.state_local_venv_dir_abs_path_inited.name)
+
+        # The `venv` is supposed to be ready when called as `func_start_app`:
+        if not os.path.exists(state_local_venv_dir_abs_path_inited):
+            raise AssertionError(f"`venv` [{state_local_venv_dir_abs_path_inited}] is not found, run `{SubCommand.command_boot.value}` first")
+
+        venv_path_to_python: str = os.path.join(
+            state_local_venv_dir_abs_path_inited,
+            ConfConstGeneral.file_rel_path_venv_python,
+        )
+        return switch_python(
+            curr_python_path=get_path_to_curr_python(),
+            next_py_exec=self.env_ctx.set_max_stride(state_stride),
+            next_python_path=venv_path_to_python,
+            start_id=state_input_start_id_var_loaded,
+            proto_code_abs_file_path=state_proto_code_file_abs_path_inited,
+        )
+
+
+# noinspection PyPep8Naming
+class Factory_state_stride_py_venv_reached(NodeFactory[StateStride]):
+
+    def create_state_node(self) -> StateNode[StateStride]:
+        if self.env_ctx._is_app:
+            return Bootstrapper_state_stride_py_venv_reached_is_app(self.env_ctx)
+        else:
+            return Bootstrapper_state_stride_py_venv_reached_not_is_app(self.env_ctx)
+
+
+# noinspection PyPep8Naming
+@conditional_factory
+class Bootstrapper_state_protoprimer_package_installed_is_app(AbstractCachingStateNode[bool]):
 
     _parent_states = staticmethod(
         lambda: [
@@ -4063,6 +4167,9 @@ class Bootstrapper_state_protoprimer_package_installed(AbstractCachingStateNode[
 
         state_input_sub_command_arg_loaded: SubCommand = self.eval_parent_state(EnvState.state_input_sub_command_arg_loaded.name)
 
+        # TODO: FT_77_15_06_50.dynamic_DAG.md:
+        #       This is not reachable for `SubCommand.command_start`.
+        #       Command `command_start` will switch to `venv_module:func_name` at `StateStride.stride_py_venv`:
         if state_input_sub_command_arg_loaded == SubCommand.command_start:
             # The only reason for `EnvState.state_protoprimer_package_installed`
             # is to install dependencies into `venv`.
@@ -4173,8 +4280,28 @@ class Bootstrapper_state_protoprimer_package_installed(AbstractCachingStateNode[
 
 
 # noinspection PyPep8Naming
-@trivial_factory
-class Bootstrapper_state_version_constraints_generated(AbstractCachingStateNode[bool]):
+@conditional_factory
+class Bootstrapper_state_protoprimer_package_installed_not_is_app(AbstractCachingStateNode[bool]):
+
+    _state_name = staticmethod(lambda: EnvState.state_protoprimer_package_installed.name)
+
+    def _eval_state_once(self) -> ValueType:
+        return False
+
+
+# noinspection PyPep8Naming
+class Factory_state_protoprimer_package_installed(NodeFactory[bool]):
+
+    def create_state_node(self) -> StateNode[bool]:
+        if self.env_ctx._is_app:
+            return Bootstrapper_state_protoprimer_package_installed_is_app(self.env_ctx)
+        else:
+            return Bootstrapper_state_protoprimer_package_installed_not_is_app(self.env_ctx)
+
+
+# noinspection PyPep8Naming
+@conditional_factory
+class Bootstrapper_state_version_constraints_generated_is_app(AbstractCachingStateNode[bool]):
     """
     Implements UC_44_82_07_30.requirements_lock.md.
     """
@@ -4194,6 +4321,9 @@ class Bootstrapper_state_version_constraints_generated(AbstractCachingStateNode[
 
         state_input_sub_command_arg_loaded: SubCommand = self.eval_parent_state(EnvState.state_input_sub_command_arg_loaded.name)
 
+        # TODO: FT_77_15_06_50.dynamic_DAG.md:
+        #       This is not reachable for `SubCommand.command_start`.
+        #       Command `command_start` will switch to `venv_module:func_name` at `StateStride.stride_py_venv`:
         if state_input_sub_command_arg_loaded == SubCommand.command_start:
             # The only reason for `EnvState.state_version_constraints_generated`
             # is to re-generate the `version_constraints.txt` file based on `venv`.
@@ -4223,8 +4353,28 @@ class Bootstrapper_state_version_constraints_generated(AbstractCachingStateNode[
 
 
 # noinspection PyPep8Naming
-@trivial_factory
-class Bootstrapper_state_stride_deps_updated_reached(AbstractCachingStateNode[StateStride]):
+@conditional_factory
+class Bootstrapper_state_version_constraints_generated_not_is_app(AbstractCachingStateNode[bool]):
+
+    _state_name = staticmethod(lambda: EnvState.state_version_constraints_generated.name)
+
+    def _eval_state_once(self) -> ValueType:
+        return False
+
+
+# noinspection PyPep8Naming
+class Factory_state_version_constraints_generated(NodeFactory[bool]):
+
+    def create_state_node(self) -> StateNode[bool]:
+        if self.env_ctx._is_app:
+            return Bootstrapper_state_version_constraints_generated_is_app(self.env_ctx)
+        else:
+            return Bootstrapper_state_version_constraints_generated_not_is_app(self.env_ctx)
+
+
+# noinspection PyPep8Naming
+@conditional_factory
+class Bootstrapper_state_stride_deps_updated_reached_is_app(AbstractCachingStateNode[StateStride]):
 
     _parent_states = staticmethod(
         lambda: [
@@ -4246,6 +4396,9 @@ class Bootstrapper_state_stride_deps_updated_reached(AbstractCachingStateNode[St
 
         state_input_sub_command_arg_loaded: SubCommand = self.eval_parent_state(EnvState.state_input_sub_command_arg_loaded.name)
 
+        # TODO: FT_77_15_06_50.dynamic_DAG.md:
+        #       This is not reachable for `SubCommand.command_start`.
+        #       Command `command_start` will switch to `venv_module:func_name` at `StateStride.stride_py_venv`:
         if state_input_sub_command_arg_loaded == SubCommand.command_start:
             # The only reason for `EnvState.state_stride_deps_updated_reached`
             # is to make `venv` dependencies effective.
@@ -4273,8 +4426,28 @@ class Bootstrapper_state_stride_deps_updated_reached(AbstractCachingStateNode[St
 
 
 # noinspection PyPep8Naming
-@trivial_factory
-class Bootstrapper_state_proto_code_updated(AbstractCachingStateNode[bool]):
+@conditional_factory
+class Bootstrapper_state_stride_deps_updated_reached_not_is_app(AbstractCachingStateNode[StateStride]):
+
+    _state_name = staticmethod(lambda: EnvState.state_stride_deps_updated_reached.name)
+
+    def _eval_state_once(self) -> ValueType:
+        return self.env_ctx.set_max_stride(StateStride.stride_deps_updated)
+
+
+# noinspection PyPep8Naming
+class Factory_state_stride_deps_updated_reached(NodeFactory[StateStride]):
+
+    def create_state_node(self) -> StateNode[StateStride]:
+        if self.env_ctx._is_app:
+            return Bootstrapper_state_stride_deps_updated_reached_is_app(self.env_ctx)
+        else:
+            return Bootstrapper_state_stride_deps_updated_reached_not_is_app(self.env_ctx)
+
+
+# noinspection PyPep8Naming
+@conditional_factory
+class Bootstrapper_state_proto_code_updated_is_app(AbstractCachingStateNode[bool]):
     """
     Return `True` if content of the `proto_kernel` has changed.
 
@@ -4300,6 +4473,9 @@ class Bootstrapper_state_proto_code_updated(AbstractCachingStateNode[bool]):
 
         state_input_sub_command_arg_loaded: SubCommand = self.eval_parent_state(EnvState.state_input_sub_command_arg_loaded.name)
 
+        # TODO: FT_77_15_06_50.dynamic_DAG.md:
+        #       This is not reachable for `SubCommand.command_start`.
+        #       Command `command_start` will switch to `venv_module:func_name` at `StateStride.stride_py_venv`:
         if state_input_sub_command_arg_loaded == SubCommand.command_start:
             # The only reason for `EnvState.state_proto_code_updated`
             # is to update sources, but that has to be done in `SubCommand.command_boot`.
@@ -4359,12 +4535,31 @@ class Bootstrapper_state_proto_code_updated(AbstractCachingStateNode[bool]):
 
 
 # noinspection PyPep8Naming
+@conditional_factory
+class Bootstrapper_state_proto_code_updated_not_is_app(AbstractCachingStateNode[bool]):
+
+    _state_name = staticmethod(lambda: EnvState.state_proto_code_updated.name)
+
+    def _eval_state_once(self) -> ValueType:
+        return False
+
+
+# noinspection PyPep8Naming
+class Factory_state_proto_code_updated(NodeFactory[bool]):
+
+    def create_state_node(self) -> StateNode[bool]:
+        if self.env_ctx._is_app:
+            return Bootstrapper_state_proto_code_updated_is_app(self.env_ctx)
+        else:
+            return Bootstrapper_state_proto_code_updated_not_is_app(self.env_ctx)
+
+
+# noinspection PyPep8Naming
 @trivial_factory
 class Bootstrapper_state_stride_src_updated_reached(AbstractCachingStateNode[StateStride]):
 
     _parent_states = staticmethod(
         lambda: [
-            EnvState.state_input_sub_command_arg_loaded.name,
             EnvState.state_input_start_id_var_loaded.name,
             EnvState.state_proto_code_file_abs_path_inited.name,
             EnvState.state_local_venv_dir_abs_path_inited.name,
@@ -4534,7 +4729,7 @@ class EnvState(enum.Enum):
     state_input_proto_code_file_abs_path_var_loaded = Bootstrapper_state_input_proto_code_file_abs_path_var_loaded
 
     # restart: `StateStride.stride_py_unknown` -> `StateStride.stride_py_arbitrary`:
-    state_stride_py_arbitrary_reached = Bootstrapper_state_stride_py_arbitrary_reached
+    state_stride_py_arbitrary_reached = Factory_state_stride_py_arbitrary_reached
 
     state_proto_code_file_abs_path_inited = Factory_state_proto_code_file_abs_path_inited
 
@@ -4598,24 +4793,23 @@ class EnvState(enum.Enum):
     # restart: `StateStride.stride_py_arbitrary` -> `StateStride.stride_py_required`:
     state_stride_py_required_reached = Factory_state_stride_py_required_reached
 
-    state_reboot_triggered = Bootstrapper_state_reboot_triggered
+    state_reboot_triggered = Factory_state_reboot_triggered
 
-    state_venv_driver_prepared = Bootstrapper_state_venv_driver_prepared
+    state_venv_driver_prepared = Factory_state_venv_driver_prepared
 
     # restart: `StateStride.stride_py_required` -> `StateStride.stride_py_venv`:
-    state_stride_py_venv_reached = Bootstrapper_state_stride_py_venv_reached
+    state_stride_py_venv_reached = Factory_state_stride_py_venv_reached
 
-    # TODO: rename to "client" (or "ref"?): `client_project_descriptors_installed`:
-    state_protoprimer_package_installed = Bootstrapper_state_protoprimer_package_installed
+    state_protoprimer_package_installed = Factory_state_protoprimer_package_installed
 
-    state_version_constraints_generated = Bootstrapper_state_version_constraints_generated
+    state_version_constraints_generated = Factory_state_version_constraints_generated
 
     # restart: `StateStride.stride_py_venv` -> `StateStride.stride_deps_updated`:
     # TODO: rename - "reached" sounds weird (and makes no sense):
-    state_stride_deps_updated_reached = Bootstrapper_state_stride_deps_updated_reached
+    state_stride_deps_updated_reached = Factory_state_stride_deps_updated_reached
 
     # TODO: rename according to the final name:
-    state_proto_code_updated = Bootstrapper_state_proto_code_updated
+    state_proto_code_updated = Factory_state_proto_code_updated
 
     # restart: `StateStride.stride_deps_updated` -> `StateStride.stride_src_updated`:
     state_stride_src_updated_reached = Bootstrapper_state_stride_src_updated_reached
@@ -4638,9 +4832,7 @@ class TargetState(enum.Enum):
     target_derived_config_loaded = EnvState.state_derived_conf_data_loaded
 
     # # FT_05_08_64_67.start_app.md
-    # TODO: FT_77_15_06_50.dynamic_DAG.md:
-    #       Can For `StateStride.stride_py_venv` be enough for `EntryFunc.func_start_app`?
-    target_venv_activated = EnvState.state_stride_src_updated_reached
+    target_venv_activated = EnvState.state_stride_py_venv_reached
 
     # FT_85_17_35_21.boot_env.md
     # The final state before switching to `PrimerRuntime.runtime_meta`:
@@ -4849,35 +5041,35 @@ class ContextBuilder:
     def __init__(self):
         self._env_ctx = EnvContext()
 
-    def entry_func(self, value: EntryFunc) -> "ContextBuilder":
+    def entry_func(self, value: EntryFunc) -> ContextBuilder:
         self._env_ctx._entry_func = value
         return self
 
-    def state_stride(self, value: StateStride) -> "ContextBuilder":
+    def state_stride(self, value: StateStride) -> ContextBuilder:
         self._env_ctx._state_stride = value
         return self
 
-    def is_app(self, value: bool) -> "ContextBuilder":
+    def is_app(self, value: bool) -> ContextBuilder:
         self._env_ctx._is_app = value
         return self
 
-    def prepare_venv(self, value: bool) -> "ContextBuilder":
+    def prepare_venv(self, value: bool) -> ContextBuilder:
         self._env_ctx._prepare_venv = value
         return self
 
-    def sub_command(self, value: SubCommand) -> "ContextBuilder":
+    def sub_command(self, value: SubCommand) -> ContextBuilder:
         self._env_ctx._sub_command = value
         return self
 
-    def is_log_enabled(self, value: bool) -> "ContextBuilder":
+    def is_log_enabled(self, value: bool) -> ContextBuilder:
         self._env_ctx._is_log_enabled = value
         return self
 
-    def final_state(self, value: str) -> "ContextBuilder":
+    def final_state(self, value: str) -> ContextBuilder:
         self._env_ctx._final_state = value
         return self
 
-    def proto_kernel_abs_path(self, value: str) -> "ContextBuilder":
+    def proto_kernel_abs_path(self, value: str) -> ContextBuilder:
         self._env_ctx._proto_kernel_abs_path = value
         return self
 
@@ -5335,7 +5527,7 @@ def get_path_to_base_python() -> str:
 
     executable_basename: str = os.path.basename(sys.executable)
 
-    # Try current `executable_basename` first.
+    # Try the current `executable_basename` first.
     # In some cases (e.g. on `macOS` with `homebrew`),
     # there are no simple basenames like `python`, instead, there are versioned ones like `python3.10`:
     path_to_next_python: str = os.path.join(
@@ -5803,18 +5995,11 @@ def _start_main(
     installed_kernel_name = f"{ConfConstGeneral.name_protoprimer_package}.{ConfConstGeneral.name_primer_kernel_module}"
 
     try:
-        # NOTE: `state_stride_src_updated_reached` forces restart with this `StateStride`:
         if curr_py_exec.value >= StateStride.stride_src_updated.value:
+            # FT_74_10_40_33.DAG_extension.md:
+            # Complete `EntryFunc.func_boot_env` with extension (if any).
             venv_module = importlib.import_module(module_name)
             selected_main = getattr(venv_module, func_name)
-            if entry_func == EntryFunc.func_start_app:
-                # TODO: FT_77_15_06_50.dynamic_DAG.md:
-                #       Can For `StateStride.stride_py_venv` be enough for `EntryFunc.func_start_app`?
-                # FT_96_50_58_75.context_propagation.md:
-                # Switch from running `proto_code` to installed `venv` code:
-                imported_kernel = importlib.import_module(installed_kernel_name)
-                setattr(imported_kernel, "_proto_kernel_abs_path", os.environ[EnvVar.var_PROTOPRIMER_PROTO_CODE.value])
-                remove_protoprimer_env_vars(os.environ)
             selected_main()
         elif curr_py_exec.value >= StateStride.stride_deps_updated.value:
             # TODO: FT_21_75_54_18.instant_scenario.md:
@@ -5830,20 +6015,36 @@ def _start_main(
             env_ctx = imported_EnvContext()
             env_ctx._entry_func = imported_EntryFunc[entry_func.name]
             imported_run_process(env_ctx)
+        elif curr_py_exec.value >= StateStride.stride_py_venv.value and entry_func == EntryFunc.func_start_app:
+            venv_module = importlib.import_module(module_name)
+            selected_main = getattr(venv_module, func_name)
+            # FT_96_50_58_75.context_propagation.md:
+            # Switch from running `proto_code` to installed `venv` code:
+            imported_kernel = importlib.import_module(installed_kernel_name)
+            setattr(imported_kernel, "_proto_kernel_abs_path", os.environ[EnvVar.var_PROTOPRIMER_PROTO_CODE.value])
+            remove_protoprimer_env_vars(os.environ)
+            selected_main()
         else:
+            # FT_14_52_73_23.primer_runtime.md:
+            # Keep running `proto_code`:
             env_ctx = EnvContext()
             env_ctx._entry_func = entry_func
             run_process(env_ctx)
-    except ImportError as e:
-        if curr_py_exec.value >= StateStride.stride_src_updated.value:
+
+    except ImportError as import_error:
+        if curr_py_exec.value >= StateStride.stride_py_venv.value and entry_func == EntryFunc.func_start_app:
             raise AssertionError(
-                f"Failed to import `{module_name}` with `{EnvVar.var_PROTOPRIMER_PY_EXEC.value}` [{curr_py_exec.name}]. "
-                # TODO: This hint is only correct for error to import anything from `protoprimer`,
-                #       not any import in general:
-                f"{get_import_error_hint(module_name)} "
+                f"Failed to import `{import_error.name}` at [{curr_py_exec.name}]. "
+                f"Has `{KeyWord.key_venv.value}` been initialized via `{SubCommand.command_boot.value}` sub command? "
                 #
-            )
-        raise e
+            ) from import_error
+        if import_error.name == installed_kernel_name:
+            raise AssertionError(
+                f"Failed to import `{installed_kernel_name}` at [{curr_py_exec.name}]. "
+                f"{get_import_error_hint(installed_kernel_name)} "
+                #
+            ) from import_error
+        raise import_error
 
 
 def _proto_main() -> None:

--- a/src/protoprimer/test/test_protoprimer/test_fast_fat_min_mocked/test_dynamic_graph/test_evaluated_state_sets.py
+++ b/src/protoprimer/test/test_protoprimer/test_fast_fat_min_mocked/test_dynamic_graph/test_evaluated_state_sets.py
@@ -21,7 +21,6 @@ from protoprimer.primer_kernel import (
     EnvState,
     EnvVar,
     StateStride,
-    SubCommand,
 )
 
 
@@ -52,7 +51,16 @@ def _verify_actual_have_no_prohibited_state_names(
 ):
     for prohibited_state_name in prohibited_state_names:
         if prohibited_state_name in actual_state_names:
-            raise AssertionError(f"`prohibited_state_name` [{prohibited_state_name}] in `actual_state_names`")
+            raise AssertionError(f"`prohibited_state_name` [{prohibited_state_name}] is in `actual_state_names`")
+
+
+def _verify_actual_have_all_mandatory_state_names(
+    mandatory_state_names: list[str],
+    actual_state_names: list[str],
+):
+    for mandatory_state_name in mandatory_state_names:
+        if mandatory_state_name not in actual_state_names:
+            raise AssertionError(f"`mandatory_state_name` [{mandatory_state_name}] is not in `actual_state_names`")
 
 
 class TestEvaluatedStateSets:
@@ -84,7 +92,8 @@ class TestEvaluatedStateSets:
             )
             os.environ[EnvVar.var_PROTOPRIMER_PROTO_CODE.value] = str(proto_kernel_abs_path)
 
-            with patch.object(sys, "argv", [str(proto_kernel_abs_path), SubCommand.command_boot.value]):
+            # Patch `argv` - otherwise, `argparse` will see args of the test runner:
+            with patch.object(sys, "argv", [str(proto_kernel_abs_path)]):
                 actual_state_names = _eval_and_collect(env_ctx)
 
         assert actual_state_names == [
@@ -144,6 +153,32 @@ class TestEvaluatedStateSets:
         # TODO: TODO_60_63_68_81.refactor_DAG_builder.md
         #       Add assertions for state_name-s which should or should not be seen in this scenario.
 
+        mandatory_state_names = [
+            # args:
+            EnvState.state_args_parsed.name,
+            # logs:
+            EnvState.state_input_stderr_log_level_handler_configured.name,
+            EnvState.state_default_file_log_handler_configured.name,
+            # main:
+            EnvState.state_everything_executed.name,
+            EnvState.state_func_boot_env_executed.name,
+            EnvState.state_command_executed.name,
+        ]
+
+        _verify_actual_have_all_mandatory_state_names(
+            mandatory_state_names,
+            actual_state_names,
+        )
+
+        prohibited_state_names = [
+            EnvState.state_func_start_app_executed.name,
+        ]
+
+        _verify_actual_have_no_prohibited_state_names(
+            prohibited_state_names,
+            actual_state_names,
+        )
+
     def test_func_start_app(self, fs: FakeFilesystem):
         """
         `EntryFunc.func_start_app`, `prepare_venv=False`: app start (venv already exists).
@@ -164,7 +199,6 @@ class TestEvaluatedStateSets:
             EnvState.state_is_app_defined.name,
             EnvState.state_input_is_stderr_log_enabled.name,
             EnvState.state_input_final_state_eval_finalized.name,
-            EnvState.state_input_sub_command_arg_loaded.name,
             EnvState.state_input_start_id_var_loaded.name,
             EnvState.state_input_proto_code_file_abs_path_var_loaded.name,
             EnvState.state_stride_py_arbitrary_reached.name,
@@ -181,40 +215,39 @@ class TestEvaluatedStateSets:
             EnvState.state_local_conf_file_abs_path_inited.name,
             EnvState.state_env_conf_file_data_loaded.name,
             EnvState.state_local_venv_dir_abs_path_inited.name,
-            EnvState.state_version_constraints_file_basename_inited.name,
-            EnvState.state_required_python_version_inited.name,
-            EnvState.state_python_selector_file_abs_path_inited.name,
-            EnvState.state_selected_python_file_abs_path_inited.name,
-            EnvState.state_local_cache_dir_abs_path_inited.name,
-            EnvState.state_venv_driver_inited.name,
-            EnvState.state_prepare_venv_finalized.name,
-            EnvState.state_local_tmp_dir_abs_path_inited.name,
-            EnvState.state_input_py_exec_var_loaded.name,
-            EnvState.state_input_stderr_log_level_var_loaded.name,
-            EnvState.state_default_stderr_log_handler_configured.name,
-            EnvState.state_input_stderr_log_level_eval_finalized.name,
-            EnvState.state_input_stderr_log_level_handler_configured.name,
-            EnvState.state_local_log_dir_abs_path_inited.name,
-            EnvState.state_default_file_log_handler_configured.name,
-            EnvState.state_stride_py_required_reached.name,
-            EnvState.state_reboot_triggered.name,
-            EnvState.state_venv_driver_prepared.name,
-            EnvState.state_project_descriptors_inited.name,
-            EnvState.state_install_specs_inited.name,
             EnvState.state_stride_py_venv_reached.name,
-            EnvState.state_protoprimer_package_installed.name,
-            EnvState.state_version_constraints_generated.name,
-            EnvState.state_stride_deps_updated_reached.name,
-            EnvState.state_proto_code_updated.name,
-            EnvState.state_stride_src_updated_reached.name,
             EnvState.state_func_start_app_executed.name,
             EnvState.state_everything_executed.name,
         ]
 
         # TODO: TODO_60_63_68_81.refactor_DAG_builder.md
         #       Add assertions for state_name-s which should or should not be seen in this scenario.
+
+        mandatory_state_names = [
+            EnvState.state_everything_executed.name,
+            EnvState.state_func_start_app_executed.name,
+            EnvState.state_stride_py_venv_reached.name,
+        ]
+
+        _verify_actual_have_all_mandatory_state_names(
+            mandatory_state_names,
+            actual_state_names,
+        )
+
         prohibited_state_names = [
-            # EnvState.state_input_sub_command_arg_loaded.name,
+            # args:
+            EnvState.state_input_sub_command_arg_loaded.name,
+            # python:
+            EnvState.state_required_python_version_inited.name,
+            EnvState.state_python_selector_file_abs_path_inited.name,
+            EnvState.state_selected_python_file_abs_path_inited.name,
+            EnvState.state_reboot_triggered.name,
+            EnvState.state_venv_driver_prepared.name,
+            # wrong func:
+            EnvState.state_func_boot_env_executed.name,
+            # logs:
+            EnvState.state_input_stderr_log_level_handler_configured.name,
+            EnvState.state_default_file_log_handler_configured.name,
         ]
 
         _verify_actual_have_no_prohibited_state_names(
@@ -272,50 +305,26 @@ class TestEvaluatedStateSets:
         # TODO: TODO_60_63_68_81.refactor_DAG_builder.md
         #       Add assertions for state_name-s which should or should not be seen in this scenario.
 
-    def test_func_call_lib_get_config_leap_derived(self, fs: FakeFilesystem):
-        """
-        `EntryFunc.func_call_lib` evaluating `state_derived_conf_data_loaded`
-        (as `get_config(ConfLeap.leap_derived)` does - no `state_everything_executed`).
-        """
-        mock_test_dir = fs.create_dir("/mock_test_dir")
-
-        with fat_mock_wrapper(fs):
-            (proto_kernel_abs_path, _, _) = create_max_layout(pathlib.Path(mock_test_dir.path))
-
-            env_ctx = _make_tracking_env_ctx(
-                entry_func=EntryFunc.func_call_lib,
-            )
-            env_ctx._proto_kernel_abs_path = str(proto_kernel_abs_path)
-
-            state_graph: TrackingStateGraph = env_ctx._state_graph
-            state_graph.eval_state(EnvState.state_derived_conf_data_loaded.name)
-            actual_state_names = state_graph.get_evaluated_state_names()
-
-        assert actual_state_names == [
-            EnvState.state_proto_code_file_abs_path_inited.name,
-            EnvState.state_primer_conf_file_abs_path_inited.name,
-            EnvState.state_print_conf_finalized.name,
-            EnvState.state_primer_conf_file_data_loaded.name,
-            EnvState.state_ref_root_dir_abs_path_inited.name,
-            EnvState.state_global_conf_dir_abs_path_inited.name,
-            EnvState.state_global_conf_file_abs_path_inited.name,
-            EnvState.state_client_conf_file_data_loaded.name,
-            EnvState.state_selected_env_dir_rel_path_inited.name,
-            EnvState.state_local_conf_symlink_abs_path_inited.name,
-            EnvState.state_local_conf_file_abs_path_inited.name,
-            EnvState.state_env_conf_file_data_loaded.name,
-            EnvState.state_required_python_version_inited.name,
-            EnvState.state_python_selector_file_abs_path_inited.name,
-            EnvState.state_selected_python_file_abs_path_inited.name,
-            EnvState.state_local_venv_dir_abs_path_inited.name,
-            EnvState.state_local_log_dir_abs_path_inited.name,
-            EnvState.state_local_tmp_dir_abs_path_inited.name,
-            EnvState.state_local_cache_dir_abs_path_inited.name,
-            EnvState.state_venv_driver_inited.name,
-            EnvState.state_version_constraints_file_basename_inited.name,
-            EnvState.state_project_descriptors_inited.name,
+        mandatory_state_names = [
+            EnvState.state_everything_executed.name,
+            EnvState.state_func_call_lib_executed.name,
             EnvState.state_derived_conf_data_loaded.name,
         ]
 
-        # TODO: TODO_60_63_68_81.refactor_DAG_builder.md
-        #       Add assertions for state_name-s which should or should not be seen in this scenario.
+        _verify_actual_have_all_mandatory_state_names(
+            mandatory_state_names,
+            actual_state_names,
+        )
+
+        prohibited_state_names = [
+            # args:
+            EnvState.state_input_sub_command_arg_loaded.name,
+            # logs:
+            EnvState.state_input_stderr_log_level_handler_configured.name,
+            EnvState.state_default_file_log_handler_configured.name,
+        ]
+
+        _verify_actual_have_no_prohibited_state_names(
+            prohibited_state_names,
+            actual_state_names,
+        )

--- a/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_func_simple/test_boot_env_and_start_app.py
+++ b/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_func_simple/test_boot_env_and_start_app.py
@@ -91,7 +91,7 @@ class TestStartMain:
         self.mock_import_module.side_effect = ImportError
 
         # when/then
-        with pytest.raises(AssertionError):
+        with pytest.raises(ImportError):
             _start_main(EntryFunc.func_boot_env, "my_module:my_func")
 
     @patch.dict(

--- a/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_graph/test_EnvContext.py
+++ b/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_graph/test_EnvContext.py
@@ -17,7 +17,7 @@ from protoprimer.primer_kernel import (
     Bootstrapper_state_env_conf_file_data_loaded,
     Bootstrapper_state_local_cache_dir_abs_path_inited,
     Bootstrapper_state_local_venv_dir_abs_path_inited,
-    Bootstrapper_state_reboot_triggered,
+    Bootstrapper_state_reboot_triggered_is_app,
     Bootstrapper_state_selected_python_file_abs_path_inited,
     ContextBuilder,
     EntryFunc,
@@ -54,7 +54,7 @@ class TestEnvContext(BasePyfakefsTestClass):
         return_value="/usr/bin/python",
     )
     @patch(
-        f"{primer_kernel.__name__}.{Bootstrapper_state_reboot_triggered.__name__}.{StateNode.eval_own_state.__name__}",
+        f"{primer_kernel.__name__}.{Bootstrapper_state_reboot_triggered_is_app.__name__}.{StateNode.eval_own_state.__name__}",
         return_value=False,
     )
     @patch(
@@ -122,7 +122,7 @@ class TestEnvContext(BasePyfakefsTestClass):
         return_value="/usr/bin/python",
     )
     @patch(
-        f"{primer_kernel.__name__}.{Bootstrapper_state_reboot_triggered.__name__}.{StateNode.eval_own_state.__name__}",
+        f"{primer_kernel.__name__}.{Bootstrapper_state_reboot_triggered_is_app.__name__}.{StateNode.eval_own_state.__name__}",
         return_value=False,
     )
     @patch(
@@ -190,7 +190,7 @@ class TestEnvContext(BasePyfakefsTestClass):
         return_value="/usr/bin/python",
     )
     @patch(
-        f"{primer_kernel.__name__}.{Bootstrapper_state_reboot_triggered.__name__}.{StateNode.eval_own_state.__name__}",
+        f"{primer_kernel.__name__}.{Bootstrapper_state_reboot_triggered_is_app.__name__}.{StateNode.eval_own_state.__name__}",
         return_value=False,
     )
     @patch(

--- a/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_proto_code_file_abs_path_inited.py
+++ b/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_proto_code_file_abs_path_inited.py
@@ -9,7 +9,7 @@ from local_test.name_assertion import assert_test_module_name_embeds_str
 from protoprimer import primer_kernel
 from protoprimer.primer_kernel import (
     Bootstrapper_state_input_proto_code_file_abs_path_var_loaded,
-    Bootstrapper_state_stride_py_arbitrary_reached,
+    Factory_state_stride_py_arbitrary_reached,
     EnvContext,
     EnvState,
     StateStride,
@@ -27,7 +27,7 @@ def test_relationship():
 
 @patch(f"{primer_kernel.__name__}.{EnvContext.__name__}.{EnvContext.get_stride.__name__}")
 @patch(f"{primer_kernel.__name__}.is_venv")
-@patch(f"{primer_kernel.__name__}.{Bootstrapper_state_stride_py_arbitrary_reached.__name__}.create_state_node")
+@patch(f"{primer_kernel.__name__}.{Factory_state_stride_py_arbitrary_reached.__name__}.create_state_node")
 @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_input_proto_code_file_abs_path_var_loaded.__name__}.create_state_node")
 def test_stride_py_arbitrary_not_in_venv(
     mock_state_input_proto_code_file_abs_path_var_loaded,
@@ -61,7 +61,7 @@ def test_stride_py_arbitrary_not_in_venv(
 
 
 @patch(f"{primer_kernel.__name__}.{EnvContext.__name__}.{EnvContext.get_stride.__name__}")
-@patch(f"{primer_kernel.__name__}.{Bootstrapper_state_stride_py_arbitrary_reached.__name__}.create_state_node")
+@patch(f"{primer_kernel.__name__}.{Factory_state_stride_py_arbitrary_reached.__name__}.create_state_node")
 @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_input_proto_code_file_abs_path_var_loaded.__name__}.create_state_node")
 def test_stride_py_venv(
     mock_state_input_proto_code_file_abs_path_var_loaded,
@@ -92,7 +92,7 @@ def test_stride_py_venv(
 
 @patch(f"{primer_kernel.__name__}.{EnvContext.__name__}.{EnvContext.get_stride.__name__}")
 @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_input_proto_code_file_abs_path_var_loaded.__name__}.create_state_node")
-@patch(f"{primer_kernel.__name__}.{Bootstrapper_state_stride_py_arbitrary_reached.__name__}.create_state_node")
+@patch(f"{primer_kernel.__name__}.{Factory_state_stride_py_arbitrary_reached.__name__}.create_state_node")
 def test_stride_py_venv_no_arg(
     mock_state_stride_py_arbitrary_reached,
     mock_state_input_proto_code_file_abs_path_var_loaded,

--- a/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_proto_code_updated.py
+++ b/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_proto_code_updated.py
@@ -10,8 +10,9 @@ from local_test.name_assertion import assert_test_module_name_embeds_str
 from protoprimer import primer_kernel
 from protoprimer.primer_kernel import (
     Factory_state_proto_code_file_abs_path_inited,
-    Bootstrapper_state_stride_deps_updated_reached,
+    Factory_state_stride_deps_updated_reached,
     ConfConstGeneral,
+    ContextBuilder,
     EnvContext,
     EnvState,
     SubCommand,
@@ -25,14 +26,20 @@ class ThisTestClass(BasePyfakefsTestClass):
 
     def setUp(self):
         self.setUpPyfakefs()
-        self.env_ctx = EnvContext()
+        self.env_ctx = (
+            ContextBuilder()
+            #
+            .is_app(True)
+            #
+            .build_context()
+        )
 
     # noinspection PyMethodMayBeStatic
     def test_relationship(self):
         assert_test_module_name_embeds_str(EnvState.state_proto_code_updated.name)
 
     @patch(f"{primer_kernel.__name__}.{Factory_state_proto_code_file_abs_path_inited.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_stride_deps_updated_reached.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_stride_deps_updated_reached.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Factory_state_input_sub_command_arg_loaded.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{EnvContext.__name__}.{EnvContext.get_stride.__name__}")
     def test_state_proto_code_updated(
@@ -95,7 +102,7 @@ class ThisTestClass(BasePyfakefsTestClass):
         return_value=True,
     )
     @patch(f"{primer_kernel.__name__}.{Factory_state_proto_code_file_abs_path_inited.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_stride_deps_updated_reached.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_stride_deps_updated_reached.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{EnvContext.__name__}.{EnvContext.get_stride.__name__}")
     @patch(f"{primer_kernel.__name__}.{Factory_state_input_sub_command_arg_loaded.__name__}.create_state_node")
     def test_import_error_when_protoprimer_is_missing(

--- a/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_protoprimer_package_installed.py
+++ b/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_protoprimer_package_installed.py
@@ -12,12 +12,13 @@ from protoprimer.primer_kernel import (
     Bootstrapper_state_project_descriptors_inited,
     Bootstrapper_state_install_specs_inited,
     Bootstrapper_state_ref_root_dir_abs_path_inited,
-    Bootstrapper_state_stride_py_venv_reached,
-    Bootstrapper_state_venv_driver_prepared,
+    Factory_state_stride_py_venv_reached,
+    Factory_state_venv_driver_prepared,
     Bootstrapper_state_version_constraints_file_basename_inited,
     CommandAction,
     ConfConstClient,
     ConfField,
+    ContextBuilder,
     EnvContext,
     EnvState,
     EnvVar,
@@ -32,7 +33,13 @@ class ThisTestClass(BasePyfakefsTestClass):
 
     def setUp(self):
         self.setUpPyfakefs()
-        self.env_ctx = EnvContext()
+        self.env_ctx = (
+            ContextBuilder()
+            #
+            .is_app(True)
+            #
+            .build_context()
+        )
 
     # noinspection PyMethodMayBeStatic
     def test_relationship(self):
@@ -40,7 +47,7 @@ class ThisTestClass(BasePyfakefsTestClass):
 
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_conf_symlink_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_ref_root_dir_abs_path_inited.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_stride_py_venv_reached.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_stride_py_venv_reached.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_project_descriptors_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_install_specs_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_version_constraints_file_basename_inited.__name__}.create_state_node")
@@ -49,7 +56,7 @@ class ThisTestClass(BasePyfakefsTestClass):
         {EnvVar.var_PROTOPRIMER_PY_EXEC.value: StateStride.stride_py_venv.name},
     )
     @patch(f"{primer_kernel.__name__}.{Factory_state_input_sub_command_arg_loaded.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_venv_driver_prepared.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_venv_driver_prepared.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{EnvContext.__name__}.{EnvContext.get_stride.__name__}")
     def test_default_install(
         self,
@@ -124,7 +131,7 @@ class ThisTestClass(BasePyfakefsTestClass):
 
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_conf_symlink_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_ref_root_dir_abs_path_inited.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_stride_py_venv_reached.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_stride_py_venv_reached.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_project_descriptors_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_install_specs_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_version_constraints_file_basename_inited.__name__}.create_state_node")
@@ -133,7 +140,7 @@ class ThisTestClass(BasePyfakefsTestClass):
         {EnvVar.var_PROTOPRIMER_PY_EXEC.value: StateStride.stride_py_venv.name},
     )
     @patch(f"{primer_kernel.__name__}.{Factory_state_input_sub_command_arg_loaded.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_venv_driver_prepared.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_venv_driver_prepared.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{EnvContext.__name__}.{EnvContext.get_stride.__name__}")
     def test_reboot(
         self,
@@ -208,7 +215,7 @@ class ThisTestClass(BasePyfakefsTestClass):
 
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_conf_symlink_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_ref_root_dir_abs_path_inited.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_stride_py_venv_reached.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_stride_py_venv_reached.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_project_descriptors_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_install_specs_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_version_constraints_file_basename_inited.__name__}.create_state_node")
@@ -217,7 +224,7 @@ class ThisTestClass(BasePyfakefsTestClass):
         {EnvVar.var_PROTOPRIMER_PY_EXEC.value: StateStride.stride_py_venv.name},
     )
     @patch(f"{primer_kernel.__name__}.{Factory_state_input_sub_command_arg_loaded.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_venv_driver_prepared.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_venv_driver_prepared.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{EnvContext.__name__}.{EnvContext.get_stride.__name__}")
     def test_grouped_install(
         self,
@@ -307,7 +314,7 @@ class ThisTestClass(BasePyfakefsTestClass):
 
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_conf_symlink_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_ref_root_dir_abs_path_inited.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_stride_py_venv_reached.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_stride_py_venv_reached.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_project_descriptors_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_install_specs_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_version_constraints_file_basename_inited.__name__}.create_state_node")
@@ -316,7 +323,7 @@ class ThisTestClass(BasePyfakefsTestClass):
         {EnvVar.var_PROTOPRIMER_PY_EXEC.value: StateStride.stride_py_venv.name},
     )
     @patch(f"{primer_kernel.__name__}.{Factory_state_input_sub_command_arg_loaded.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_venv_driver_prepared.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_venv_driver_prepared.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{EnvContext.__name__}.{EnvContext.get_stride.__name__}")
     def test_nothing_to_install(
         self,

--- a/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_reboot_triggered.py
+++ b/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_reboot_triggered.py
@@ -15,12 +15,12 @@ from protoprimer.primer_kernel import (
     Bootstrapper_state_local_tmp_dir_abs_path_inited,
     Bootstrapper_state_local_venv_dir_abs_path_inited,
     Bootstrapper_state_version_constraints_file_basename_inited,
+    ContextBuilder,
     Factory_state_prepare_venv_finalized,
     Factory_state_proto_code_file_abs_path_inited,
     Factory_state_stride_py_required_reached,
     CommandAction,
     ConfConstEnv,
-    EnvContext,
     EnvState,
     SubCommand,
     StateStride,
@@ -30,7 +30,13 @@ from protoprimer.primer_kernel import (
 
 @pytest.fixture
 def env_ctx():
-    return EnvContext()
+    return (
+        ContextBuilder()
+        #
+        .is_app(True)
+        #
+        .build_context()
+    )
 
 
 def test_relationship():

--- a/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_stride_deps_updated_reached.py
+++ b/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_stride_deps_updated_reached.py
@@ -10,8 +10,8 @@ from protoprimer import primer_kernel
 from protoprimer.primer_kernel import (
     Bootstrapper_state_input_start_id_var_loaded,
     Factory_state_proto_code_file_abs_path_inited,
-    Bootstrapper_state_version_constraints_generated,
-    EnvContext,
+    Factory_state_version_constraints_generated,
+    ContextBuilder,
     EnvState,
     SubCommand,
     StateStride,
@@ -22,7 +22,13 @@ from protoprimer.primer_kernel import (
 
 @pytest.fixture
 def env_ctx():
-    return EnvContext()
+    return (
+        ContextBuilder()
+        #
+        .is_app(True)
+        #
+        .build_context()
+    )
 
 
 def test_relationship():
@@ -35,7 +41,7 @@ def test_relationship():
 @patch(f"{primer_kernel.__name__}.{Factory_state_proto_code_file_abs_path_inited.__name__}.create_state_node")
 @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_venv_dir_abs_path_inited.__name__}.create_state_node")
 @patch(f"{primer_kernel.__name__}.{Factory_state_input_sub_command_arg_loaded.__name__}.create_state_node")
-@patch(f"{primer_kernel.__name__}.{Bootstrapper_state_version_constraints_generated.__name__}.create_state_node")
+@patch(f"{primer_kernel.__name__}.{Factory_state_version_constraints_generated.__name__}.create_state_node")
 def test_stride_py_required_to_next_stride_deps_updated(
     mock_state_version_constraints_generated,
     mock_state_input_sub_command_arg_loaded,
@@ -88,7 +94,7 @@ def test_stride_py_required_to_next_stride_deps_updated(
 @patch(f"{primer_kernel.__name__}.{Factory_state_proto_code_file_abs_path_inited.__name__}.create_state_node")
 @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_venv_dir_abs_path_inited.__name__}.create_state_node")
 @patch(f"{primer_kernel.__name__}.{Factory_state_input_sub_command_arg_loaded.__name__}.create_state_node")
-@patch(f"{primer_kernel.__name__}.{Bootstrapper_state_version_constraints_generated.__name__}.create_state_node")
+@patch(f"{primer_kernel.__name__}.{Factory_state_version_constraints_generated.__name__}.create_state_node")
 @patch(f"{primer_kernel.__name__}.get_path_to_curr_python")
 def test_stride_deps_updated_to_same_stride_deps_updated(
     mock_switch_python,

--- a/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_stride_py_arbitrary_reached.py
+++ b/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_stride_py_arbitrary_reached.py
@@ -12,7 +12,7 @@ from protoprimer.primer_kernel import (
     Factory_state_input_sub_command_arg_loaded,
     Bootstrapper_state_input_start_id_var_loaded,
     ConfConstInput,
-    EnvContext,
+    ContextBuilder,
     EnvState,
     StateStride,
 )
@@ -20,7 +20,13 @@ from protoprimer.primer_kernel import (
 
 @pytest.fixture
 def env_ctx():
-    return EnvContext()
+    return (
+        ContextBuilder()
+        #
+        .is_app(True)
+        #
+        .build_context()
+    )
 
 
 def test_relationship():

--- a/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_stride_py_required_reached.py
+++ b/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_stride_py_required_reached.py
@@ -17,13 +17,13 @@ from protoprimer.primer_kernel import (
     Factory_state_prepare_venv_finalized,
     Factory_state_proto_code_file_abs_path_inited,
     Bootstrapper_state_selected_python_file_abs_path_inited,
+    Factory_state_input_sub_command_arg_loaded,
     ConfConstEnv,
     ConfConstGeneral,
     EnvContext,
     EnvState,
     StateStride,
     SubCommand,
-    Factory_state_input_sub_command_arg_loaded,
 )
 
 mock_client_dir = "/mock_client_dir"
@@ -81,10 +81,8 @@ class ThisTestClass(BasePyfakefsTestClass):
     @patch(f"{primer_kernel.__name__}.os.execve")
     @patch(f"{primer_kernel.__name__}.subprocess.check_call")
     @patch(f"{primer_kernel.__name__}.{Factory_state_prepare_venv_finalized.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Factory_state_input_sub_command_arg_loaded.__name__}.create_state_node")
     def test_success_on_arbitrary_py_exec_outside_venv(
         self,
-        mock_input_sub_command_arg_loaded,
         mock_state_prepare_venv_finalized,
         mock_check_call,
         mock_execve,

--- a/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_stride_py_venv_reached.py
+++ b/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_stride_py_venv_reached.py
@@ -17,11 +17,12 @@ from protoprimer.primer_kernel import (
     Bootstrapper_state_local_conf_file_abs_path_inited,
     Bootstrapper_state_local_venv_dir_abs_path_inited,
     Factory_state_proto_code_file_abs_path_inited,
-    Bootstrapper_state_reboot_triggered,
+    Factory_state_reboot_triggered,
     Bootstrapper_state_selected_python_file_abs_path_inited,
-    Bootstrapper_state_venv_driver_prepared,
+    Factory_state_venv_driver_prepared,
     ConfConstEnv,
     ConfConstGeneral,
+    ContextBuilder,
     EnvContext,
     EnvState,
     EnvVar,
@@ -46,7 +47,13 @@ class ThisTestClass(BasePyfakefsTestClass):
 
     def setUp(self):
         self.setUpPyfakefs()
-        self.env_ctx = EnvContext()
+        self.env_ctx = (
+            ContextBuilder()
+            #
+            .is_app(True)
+            #
+            .build_context()
+        )
 
         self.fs.create_dir(mock_client_dir)
         os.chdir(mock_client_dir)
@@ -71,12 +78,12 @@ class ThisTestClass(BasePyfakefsTestClass):
     @patch.dict(f"{os.__name__}.environ", {}, clear=True)
     @patch.object(sys, "argv", ["/path/to/script.py", "--some-arg"])
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_input_start_id_var_loaded.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_reboot_triggered.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_reboot_triggered.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Factory_state_proto_code_file_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_conf_file_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_venv_dir_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_selected_python_file_abs_path_inited.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_venv_driver_prepared.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_venv_driver_prepared.__name__}.create_state_node")
     @patch(
         f"{primer_kernel.__name__}.get_path_to_curr_python",
         return_value=test_python_abs_path,
@@ -150,12 +157,12 @@ class ThisTestClass(BasePyfakefsTestClass):
     ####################################################################################################################
     @patch.dict(f"{os.__name__}.environ", {}, clear=True)
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_input_start_id_var_loaded.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_reboot_triggered.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_reboot_triggered.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Factory_state_proto_code_file_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_conf_file_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_venv_dir_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_selected_python_file_abs_path_inited.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_venv_driver_prepared.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_venv_driver_prepared.__name__}.create_state_node")
     @patch(
         f"{primer_kernel.__name__}.get_path_to_curr_python",
         return_value="/mock_client_dir/venv/wrong/path/to/python",
@@ -207,12 +214,12 @@ class ThisTestClass(BasePyfakefsTestClass):
     ####################################################################################################################
     @patch.dict(f"{os.__name__}.environ", {}, clear=True)
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_input_start_id_var_loaded.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_reboot_triggered.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_reboot_triggered.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Factory_state_proto_code_file_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_conf_file_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_venv_dir_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_selected_python_file_abs_path_inited.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_venv_driver_prepared.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_venv_driver_prepared.__name__}.create_state_node")
     @patch(
         f"{primer_kernel.__name__}.get_path_to_curr_python",
         # expected path to `python`:
@@ -266,12 +273,12 @@ class ThisTestClass(BasePyfakefsTestClass):
     @patch.dict(f"{os.__name__}.environ", {}, clear=True)
     @patch.object(sys, "argv", ["/path/to/script.py", "--some-arg"])
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_input_start_id_var_loaded.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_reboot_triggered.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_reboot_triggered.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Factory_state_proto_code_file_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_conf_file_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_venv_dir_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_selected_python_file_abs_path_inited.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_venv_driver_prepared.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_venv_driver_prepared.__name__}.create_state_node")
     @patch(
         f"{primer_kernel.__name__}.get_path_to_curr_python",
         return_value=test_python_abs_path,
@@ -326,12 +333,12 @@ class ThisTestClass(BasePyfakefsTestClass):
     @patch.dict(f"{os.__name__}.environ", {}, clear=True)
     @patch.object(sys, "argv", ["/path/to/script.py", "--some-arg"])
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_input_start_id_var_loaded.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_reboot_triggered.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_reboot_triggered.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Factory_state_proto_code_file_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_conf_file_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_venv_dir_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_selected_python_file_abs_path_inited.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_venv_driver_prepared.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_venv_driver_prepared.__name__}.create_state_node")
     @patch(
         f"{primer_kernel.__name__}.get_path_to_curr_python",
         return_value=test_python_abs_path,
@@ -407,12 +414,12 @@ class ThisTestClass(BasePyfakefsTestClass):
     @patch.dict(f"{os.__name__}.environ", {}, clear=True)
     @patch.object(sys, "argv", ["/path/to/script.py", "--some-arg"])
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_input_start_id_var_loaded.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_reboot_triggered.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_reboot_triggered.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Factory_state_proto_code_file_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_conf_file_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_venv_dir_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_selected_python_file_abs_path_inited.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_venv_driver_prepared.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_venv_driver_prepared.__name__}.create_state_node")
     @patch(
         f"{primer_kernel.__name__}.get_path_to_curr_python",
         return_value=non_default_file_abs_path_python,
@@ -486,12 +493,12 @@ class ThisTestClass(BasePyfakefsTestClass):
     @patch.dict(f"{os.__name__}.environ", {}, clear=True)
     @patch.object(sys, "argv", ["/path/to/script.py", "--some-arg"])
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_input_start_id_var_loaded.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_reboot_triggered.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_reboot_triggered.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Factory_state_proto_code_file_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_conf_file_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_venv_dir_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_selected_python_file_abs_path_inited.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_venv_driver_prepared.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_venv_driver_prepared.__name__}.create_state_node")
     @patch(
         f"{primer_kernel.__name__}.get_path_to_curr_python",
         return_value="/a/different/python",
@@ -570,12 +577,12 @@ class ThisTestClass(BasePyfakefsTestClass):
     )
     @patch.object(sys, "argv", ["/path/to/script.py", "--some-arg"])
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_input_start_id_var_loaded.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_reboot_triggered.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_reboot_triggered.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Factory_state_proto_code_file_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_conf_file_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_venv_dir_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_selected_python_file_abs_path_inited.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_venv_driver_prepared.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_venv_driver_prepared.__name__}.create_state_node")
     @patch(
         f"{primer_kernel.__name__}.get_path_to_curr_python",
     )
@@ -620,12 +627,12 @@ class ThisTestClass(BasePyfakefsTestClass):
     @patch.object(sys, "argv", ["/path/to/script.py", "--some-arg"])
     @patch(f"{primer_kernel.__name__}.logger.info")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_input_start_id_var_loaded.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_reboot_triggered.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_reboot_triggered.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Factory_state_proto_code_file_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_conf_file_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_venv_dir_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_selected_python_file_abs_path_inited.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_venv_driver_prepared.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_venv_driver_prepared.__name__}.create_state_node")
     @patch(
         f"{primer_kernel.__name__}.get_path_to_curr_python",
         return_value=test_python_abs_path,
@@ -700,12 +707,12 @@ class ThisTestClass(BasePyfakefsTestClass):
     ####################################################################################################################
     @patch.dict(f"{os.__name__}.environ", {}, clear=True)
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_input_start_id_var_loaded.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_reboot_triggered.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_reboot_triggered.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Factory_state_proto_code_file_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_conf_file_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_venv_dir_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_selected_python_file_abs_path_inited.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_venv_driver_prepared.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_venv_driver_prepared.__name__}.create_state_node")
     @patch(
         f"{primer_kernel.__name__}.get_path_to_curr_python",
         return_value=test_python_abs_path,

--- a/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_stride_src_updated_reached.py
+++ b/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_stride_src_updated_reached.py
@@ -9,13 +9,11 @@ from protoprimer import primer_kernel
 from protoprimer.primer_kernel import (
     Bootstrapper_state_input_start_id_var_loaded,
     Factory_state_proto_code_file_abs_path_inited,
-    Bootstrapper_state_proto_code_updated,
-    EnvContext,
+    Factory_state_proto_code_updated,
+    ContextBuilder,
     EnvState,
-    SubCommand,
     StateStride,
     Bootstrapper_state_local_venv_dir_abs_path_inited,
-    Factory_state_input_sub_command_arg_loaded,
 )
 
 
@@ -24,22 +22,24 @@ class ThisTestClass(BasePyfakefsTestClass):
 
     def setUp(self):
         self.setUpPyfakefs()
-        self.env_ctx = EnvContext()
+        self.env_ctx = (
+            ContextBuilder()
+            #
+            .build_context()
+        )
 
     # noinspection PyMethodMayBeStatic
     def test_relationship(self):
         assert_test_module_name_embeds_str(EnvState.state_stride_src_updated_reached.name)
 
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_input_start_id_var_loaded.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_proto_code_updated.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_proto_code_updated.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Factory_state_proto_code_file_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_venv_dir_abs_path_inited.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Factory_state_input_sub_command_arg_loaded.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.switch_python")
     def test_not_yet_at_required_python(
         self,
         mock_switch_python,
-        mock_state_input_sub_command_arg_loaded,
         mock_state_local_venv_dir_abs_path_inited,
         mock_state_proto_code_file_abs_path_inited,
         mock_state_proto_code_updated,
@@ -61,7 +61,6 @@ class ThisTestClass(BasePyfakefsTestClass):
 
         self.env_ctx._state_stride = StateStride.stride_py_unknown
 
-        mock_state_input_sub_command_arg_loaded.return_value.eval_own_state.return_value = SubCommand.command_boot
         mock_state_local_venv_dir_abs_path_inited.return_value.eval_own_state.return_value = "/path/to/venv"
         self.fs.create_file("/path/to/venv/bin/python")
 
@@ -80,15 +79,13 @@ class ThisTestClass(BasePyfakefsTestClass):
         )
 
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_input_start_id_var_loaded.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_proto_code_updated.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_proto_code_updated.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Factory_state_proto_code_file_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_venv_dir_abs_path_inited.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Factory_state_input_sub_command_arg_loaded.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.switch_python")
     def test_already_required_python(
         self,
         mock_switch_python,
-        mock_state_input_sub_command_arg_loaded,
         mock_state_local_venv_dir_abs_path_inited,
         mock_state_proto_code_file_abs_path_inited,
         mock_state_proto_code_updated,
@@ -113,7 +110,6 @@ class ThisTestClass(BasePyfakefsTestClass):
 
         self.env_ctx._state_stride = StateStride.stride_src_updated
 
-        mock_state_input_sub_command_arg_loaded.return_value.eval_own_state.return_value = SubCommand.command_boot
         mock_state_local_venv_dir_abs_path_inited.return_value.eval_own_state.return_value = "/path/to/venv"
 
         # when:

--- a/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_venv_driver_prepared.py
+++ b/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_venv_driver_prepared.py
@@ -12,10 +12,10 @@ from local_test.name_assertion import assert_test_module_name_embeds_str
 from protoprimer import primer_kernel
 from protoprimer.primer_kernel import (
     Bootstrapper_state_local_cache_dir_abs_path_inited,
-    Bootstrapper_state_reboot_triggered,
+    Factory_state_reboot_triggered,
     Bootstrapper_state_selected_python_file_abs_path_inited,
     Bootstrapper_state_venv_driver_inited,
-    EnvContext,
+    ContextBuilder,
     EnvState,
     VenvDriverPip,
     VenvDriverType,
@@ -27,7 +27,13 @@ from protoprimer.primer_kernel import (
 
 @pytest.fixture
 def env_ctx():
-    return EnvContext()
+    return (
+        ContextBuilder()
+        #
+        .is_app(True)
+        #
+        .build_context()
+    )
 
 
 def test_relationship():
@@ -36,7 +42,7 @@ def test_relationship():
 
 @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_venv_dir_abs_path_inited.__name__}.create_state_node")
 @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_venv_driver_inited.__name__}.create_state_node")
-@patch(f"{primer_kernel.__name__}.{Bootstrapper_state_reboot_triggered.__name__}.create_state_node")
+@patch(f"{primer_kernel.__name__}.{Factory_state_reboot_triggered.__name__}.create_state_node")
 @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_cache_dir_abs_path_inited.__name__}.create_state_node")
 @patch("protoprimer.primer_kernel.Bootstrapper_required_python_version_inited.create_state_node")
 @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_selected_python_file_abs_path_inited.__name__}.create_state_node")
@@ -75,7 +81,7 @@ def test_pip_driver_inited(
 @patch(f"{primer_kernel.__name__}.VenvDriverPip.create_venv")
 @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_venv_dir_abs_path_inited.__name__}.create_state_node")
 @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_venv_driver_inited.__name__}.create_state_node")
-@patch(f"{primer_kernel.__name__}.{Bootstrapper_state_reboot_triggered.__name__}.create_state_node")
+@patch(f"{primer_kernel.__name__}.{Factory_state_reboot_triggered.__name__}.create_state_node")
 @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_cache_dir_abs_path_inited.__name__}.create_state_node")
 @patch("protoprimer.primer_kernel.Bootstrapper_required_python_version_inited.create_state_node")
 @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_selected_python_file_abs_path_inited.__name__}.create_state_node")
@@ -120,7 +126,7 @@ def test_uv_driver_inited_when_not_installed(
 @patch(f"{primer_kernel.__name__}.VenvDriverPip.create_venv")
 @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_venv_dir_abs_path_inited.__name__}.create_state_node")
 @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_venv_driver_inited.__name__}.create_state_node")
-@patch(f"{primer_kernel.__name__}.{Bootstrapper_state_reboot_triggered.__name__}.create_state_node")
+@patch(f"{primer_kernel.__name__}.{Factory_state_reboot_triggered.__name__}.create_state_node")
 @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_cache_dir_abs_path_inited.__name__}.create_state_node")
 @patch("protoprimer.primer_kernel.Bootstrapper_required_python_version_inited.create_state_node")
 @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_selected_python_file_abs_path_inited.__name__}.create_state_node")
@@ -162,7 +168,7 @@ def test_uv_driver_inited_when_already_installed(
 
 @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_venv_dir_abs_path_inited.__name__}.create_state_node")
 @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_venv_driver_inited.__name__}.create_state_node")
-@patch(f"{primer_kernel.__name__}.{Bootstrapper_state_reboot_triggered.__name__}.create_state_node")
+@patch(f"{primer_kernel.__name__}.{Factory_state_reboot_triggered.__name__}.create_state_node")
 @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_cache_dir_abs_path_inited.__name__}.create_state_node")
 @patch("protoprimer.primer_kernel.Bootstrapper_required_python_version_inited.create_state_node")
 @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_selected_python_file_abs_path_inited.__name__}.create_state_node")

--- a/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_version_constraints_generated.py
+++ b/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_version_constraints_generated.py
@@ -11,10 +11,11 @@ from local_test.name_assertion import assert_test_module_name_embeds_str
 from protoprimer import primer_kernel
 from protoprimer.primer_kernel import (
     Bootstrapper_state_local_conf_symlink_abs_path_inited,
-    Bootstrapper_state_protoprimer_package_installed,
-    Bootstrapper_state_venv_driver_prepared,
+    Factory_state_protoprimer_package_installed,
+    Factory_state_venv_driver_prepared,
     Bootstrapper_state_version_constraints_file_basename_inited,
     ConfConstEnv,
+    ContextBuilder,
     EnvContext,
     EnvState,
     Factory_state_input_sub_command_arg_loaded,
@@ -26,14 +27,20 @@ class ThisTestClass(BasePyfakefsTestClass):
 
     def setUp(self):
         self.setUpPyfakefs()
-        self.env_ctx = EnvContext()
+        self.env_ctx = (
+            ContextBuilder()
+            #
+            .is_app(True)
+            #
+            .build_context()
+        )
 
     # noinspection PyMethodMayBeStatic
     def test_relationship(self):
         assert_test_module_name_embeds_str(EnvState.state_version_constraints_generated.name)
 
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_protoprimer_package_installed.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_venv_driver_prepared.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_protoprimer_package_installed.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_venv_driver_prepared.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_version_constraints_file_basename_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_conf_symlink_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Factory_state_input_sub_command_arg_loaded.__name__}.create_state_node")
@@ -53,7 +60,13 @@ class ThisTestClass(BasePyfakefsTestClass):
             EnvState.state_version_constraints_generated.name,
         )
         self.fs.reset()
-        self.env_ctx = EnvContext()
+        self.env_ctx = (
+            ContextBuilder()
+            #
+            .is_app(True)
+            #
+            .build_context()
+        )
         mock_state_protoprimer_package_installed.return_value.eval_own_state.return_value = True
         mock_client_conf_env_dir = "/mock_client_conf_env_dir"
         self.fs.create_dir(mock_client_conf_env_dir)
@@ -79,8 +92,8 @@ class ThisTestClass(BasePyfakefsTestClass):
         self.assertTrue(os.path.exists(constraints_txt_path))
         mock_state_venv_driver_prepared.return_value.eval_own_state.return_value.pin_versions.assert_called_once()
 
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_protoprimer_package_installed.__name__}.create_state_node")
-    @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_venv_driver_prepared.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_protoprimer_package_installed.__name__}.create_state_node")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_venv_driver_prepared.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_version_constraints_file_basename_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_conf_symlink_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Factory_state_input_sub_command_arg_loaded.__name__}.create_state_node")
@@ -98,7 +111,13 @@ class ThisTestClass(BasePyfakefsTestClass):
             EnvState.state_version_constraints_generated.name,
         )
         self.fs.reset()
-        self.env_ctx = EnvContext()
+        self.env_ctx = (
+            ContextBuilder()
+            #
+            .is_app(True)
+            #
+            .build_context()
+        )
         mock_state_protoprimer_package_installed.return_value.eval_own_state.return_value = False
         mock_client_conf_env_dir = "/mock_client_conf_env_dir"
         self.fs.create_dir(mock_client_conf_env_dir)


### PR DESCRIPTION
*   Switch to `venv_module:func_name` on `stride_py_required` for `EntryFunc.func_app_start`.
*   Split via `Factory_*`:
    *   `EnvState.state_stride_py_arbitrary_reached`
    *   `EnvState.state_reboot_triggered`
    *   `EnvState.state_venv_driver_prepared`
    *   `EnvState.state_stride_py_venv_reached`
    *   `EnvState.state_protoprimer_package_installed`
    *   `EnvState.state_version_constraints_generated`
    *   `EnvState.state_stride_deps_updated_reached`
    *   `EnvState.state_proto_code_updated`
*   Improve `import` error hints in `_start_main`.
*   Docs: keep the same background for menu items on the narrow page.
