### PR TITLE
Improve `ContexBuilder`

### DIFF
--- a/cmd/proto_code/proto_kernel.py
+++ b/cmd/proto_code/proto_kernel.py
@@ -24,59 +24,48 @@
 from __future__ import annotations
 
 import argparse
-import ast
-import atexit
 import contextvars
 import datetime
 import enum
 import importlib
-import importlib.util
 import json
 import logging
 import os
 import pathlib
-import re
 import shlex
 import shutil
-import site
 import subprocess
 import sys
-import types
 import typing
-from typing import (
-    Any,
-    Callable,
-    Generic,
-    MutableMapping,
-    TypeVar,
-)
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
 # The release process ensures that content in this file matches the version below while tagging the release commit
 # (otherwise, if the file comes from a different commit, the version is irrelevant):
-__version__ = "0.12.2.dev0"
-
+__version__ = "0.13.0.dev0"
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
 logger: logging.Logger = logging.getLogger()
 
 log_stride = contextvars.ContextVar("state_stride")
 
-ValueType = TypeVar("ValueType")
-DataValueType = TypeVar("DataValueType")
+ValueType = typing.TypeVar("ValueType")
+DataValueType = typing.TypeVar("DataValueType")
 
 # FT_96_50_58_75.context_propagation.md:
 # It is only set on `EntryFunc.func_start_app` as default for `EntryFunc.func_call_lib`.
-# `EnvContext._proto_kernel_abs_path` overrides it.
+# `EnvContext._forced_proto_kernel_abs_path` overrides it.
 _proto_kernel_abs_path: str | None = None
 
 
 def run_process(env_ctx: EnvContext) -> None:
+    import atexit
+
     # See UC_10_80_27_57.extend_DAG.md
     try:
         ensure_min_python_version()
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
         state_everything_executed: bool = env_ctx.eval_state(TargetState.target_everything_executed.value.name)
         assert state_everything_executed
         atexit.register(lambda: env_ctx.print_exit_line(0))
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
     except subprocess.CalledProcessError as subproc_error:
         # Convert the list of arguments into a single shell-escaped string:
         if isinstance(subproc_error.cmd, list):
@@ -1002,7 +991,7 @@ class ShellType(enum.Enum):
     shell_zsh = "zsh"
 
 
-def remove_protoprimer_env_vars(env_vars: MutableMapping[str, str]) -> None:
+def remove_protoprimer_env_vars(env_vars: typing.MutableMapping[str, str]) -> None:
     """
     FT_66_02_54_56.context_isolation.md
     """
@@ -1652,7 +1641,7 @@ class ExitCodeReporter(RunStrategy):
         But it may not reach all nodes because
         dependencies will be conditionally evaluated by the implementation of those nodes.
         """
-        # NOTE: The `EnvContext._final_state` must return `int` with this strategy:
+        # NOTE: The `EnvContext._forced_final_state` must return `int` with this strategy:
         exit_code: int = self.env_ctx.eval_state(state_node.state_name)
         if type(exit_code) is not int:
             raise AssertionError("`exit_code` must be an `int`")
@@ -1662,7 +1651,7 @@ class ExitCodeReporter(RunStrategy):
 ########################################################################################################################
 
 
-class StateNode(Generic[ValueType]):
+class StateNode(typing.Generic[ValueType]):
     """
     All nodes form a `StateGraph`, which must be a DAG.
     """
@@ -1712,7 +1701,7 @@ class StateNode(Generic[ValueType]):
 
 # FT_84_11_73_28.supported_python_versions.md:
 # With min `python` switched to 3.8, `NodeFactory` can be turned into `typing.Protocol`:
-class NodeFactory(Generic[ValueType]):
+class NodeFactory(typing.Generic[ValueType]):
 
     def __init__(
         self,
@@ -1724,7 +1713,7 @@ class NodeFactory(Generic[ValueType]):
         raise NotImplementedError()
 ########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
 
-StateNodeSubclass = TypeVar("StateNodeSubclass", bound=StateNode)
+StateNodeSubclass = typing.TypeVar("StateNodeSubclass", bound=StateNode)
 
 
 def conditional_factory(state_node_class: type[StateNodeSubclass]) -> type[StateNodeSubclass]:
@@ -1750,8 +1739,8 @@ def trivial_factory(state_node_class: type[StateNodeSubclass]) -> type[NodeFacto
 
 
 class AbstractCachingStateNode(StateNode[ValueType]):
-    _parent_states: Callable[[], list[str]] = staticmethod(lambda: [])
-    _state_name: Callable[[], str]
+    _parent_states: typing.Callable[[], list[str]] = staticmethod(lambda: [])
+    _state_name: typing.Callable[[], str]
 
     def __init__(
         self,
@@ -1847,6 +1836,7 @@ class Bootstrapper_state_is_app_defined(AbstractCachingStateNode[bool]):
 @trivial_factory
 class Bootstrapper_state_input_is_stderr_log_enabled(AbstractCachingStateNode[bool]):
 
+    _parent_states = staticmethod(lambda: [EnvState.state_is_app_defined.name])
     _state_name = staticmethod(lambda: EnvState.state_input_is_stderr_log_enabled.name)
 
     def _eval_state_once(self) -> ValueType:
@@ -1909,11 +1899,7 @@ class Bootstrapper_state_input_stderr_log_level_var_loaded(AbstractCachingStateN
 class Bootstrapper_state_default_stderr_log_handler_configured(AbstractCachingStateNode[logging.Handler]):
     # TODO: UC_81_50_97_17.do_not_reuse_logger.md: Shell we disable configuring loggers for `EntryFunc.func_start_app`?
 
-    _parent_states = staticmethod(
-        lambda: [
-            EnvState.state_input_stderr_log_level_var_loaded.name,
-        ]
-    )
+    _parent_states = staticmethod(lambda: [EnvState.state_input_stderr_log_level_var_loaded.name])
     _state_name = staticmethod(lambda: EnvState.state_default_stderr_log_handler_configured.name)
 
     def _eval_state_once(self) -> ValueType:
@@ -1924,13 +1910,13 @@ class Bootstrapper_state_default_stderr_log_handler_configured(AbstractCachingSt
         assert state_input_stderr_log_level_var_loaded >= 0
 
         stderr_handler: logging.Handler = _configure_primer_stderr_log_handler(state_input_stderr_log_level_var_loaded)
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
         return stderr_handler
 
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
 # noinspection PyPep8Naming
 @conditional_factory
-class Bootstrapper_state_args_parsed_func_boot_env(AbstractCachingStateNode[argparse.Namespace]):
+class Bootstrapper_state_args_parsed_is_app(AbstractCachingStateNode[argparse.Namespace]):
 
     _state_name = staticmethod(lambda: EnvState.state_args_parsed.name)
 
@@ -1938,35 +1924,30 @@ class Bootstrapper_state_args_parsed_func_boot_env(AbstractCachingStateNode[argp
         return parse_args()
 
 
-# TODO: FT_77_15_06_50.dynamic_DAG.md:
-#       Do we still need this? Assert at Factory instead.
 # noinspection PyPep8Naming
 @conditional_factory
-class Bootstrapper_state_args_parsed_not_func_boot_env(AbstractCachingStateNode[argparse.Namespace]):
+class Bootstrapper_state_args_parsed_not_is_app(AbstractCachingStateNode[argparse.Namespace]):
 
     _state_name = staticmethod(lambda: EnvState.state_args_parsed.name)
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
     def _eval_state_once(self) -> ValueType:
-        raise AssertionError(f"`{EnvState.state_args_parsed.name}` must not be evaluated for `{self.env_ctx._entry_func}`")
+        raise AssertionError(f"`{EnvState.state_args_parsed.name}` must not be reachable in this context")
 
 
 # noinspection PyPep8Naming
 class Factory_state_args_parsed(NodeFactory[StateStride]):
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
     def create_state_node(self) -> StateNode[ValueType]:
-        # TODO: FT_77_15_06_50.dynamic_DAG.md:
-        #       This step should not be executed without need to parse args.
-        #       Do not fake args. Just redesign dependency. No?
         if self.env_ctx._is_app:
-            return Bootstrapper_state_args_parsed_func_boot_env(self.env_ctx)
+            return Bootstrapper_state_args_parsed_is_app(self.env_ctx)
         else:
-            return Bootstrapper_state_args_parsed_not_func_boot_env(self.env_ctx)
+            return Bootstrapper_state_args_parsed_not_is_app(self.env_ctx)
 
 
 # noinspection PyPep8Naming
 @conditional_factory
-class Bootstrapper_state_input_stderr_log_level_eval_finalized_func_boot_env(AbstractCachingStateNode[int]):
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+class Bootstrapper_state_input_stderr_log_level_eval_finalized_is_app(AbstractCachingStateNode[int]):
+
     _parent_states = staticmethod(
         lambda: [
             EnvState.state_input_stderr_log_level_var_loaded.name,
@@ -1976,7 +1957,7 @@ class Bootstrapper_state_input_stderr_log_level_eval_finalized_func_boot_env(Abs
     _state_name = staticmethod(lambda: EnvState.state_input_stderr_log_level_eval_finalized.name)
 
     def _eval_state_once(self) -> ValueType:
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
         state_input_stderr_log_level_var_loaded: int = self.eval_parent_state(EnvState.state_input_stderr_log_level_var_loaded.name)
 
         parsed_args = self.eval_parent_state(EnvState.state_args_parsed.name)
@@ -1988,7 +1969,7 @@ class Bootstrapper_state_input_stderr_log_level_eval_finalized_func_boot_env(Abs
             parsed_args,
             SyntaxArg.dest_verbose,
         )
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
         state_input_stderr_log_level_eval_finalized: int
         if stderr_log_level_quiet_count == 0 and stderr_log_level_verbose_count == 0:
             state_input_stderr_log_level_eval_finalized = state_input_stderr_log_level_var_loaded
@@ -1999,7 +1980,7 @@ class Bootstrapper_state_input_stderr_log_level_eval_finalized_func_boot_env(Abs
                 logging,
                 ConfConstInput.default_PROTOPRIMER_STDERR_LOG_LEVEL,
             )
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
             relative_log_level = 10 * (stderr_log_level_quiet_count - stderr_log_level_verbose_count)
 
             state_input_stderr_log_level_eval_finalized = base_log_level + relative_log_level
@@ -2009,33 +1990,26 @@ class Bootstrapper_state_input_stderr_log_level_eval_finalized_func_boot_env(Abs
 
         return state_input_stderr_log_level_eval_finalized
 
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
 # noinspection PyPep8Naming
 @conditional_factory
-class Bootstrapper_state_input_stderr_log_level_eval_finalized_not_func_boot_env(AbstractCachingStateNode[int]):
+class Bootstrapper_state_input_stderr_log_level_eval_finalized_not_is_app(AbstractCachingStateNode[int]):
 
-    _parent_states = staticmethod(
-        lambda: [
-            EnvState.state_input_stderr_log_level_var_loaded.name,
-        ]
-    )
+    _parent_states = staticmethod(lambda: [EnvState.state_input_stderr_log_level_var_loaded.name])
     _state_name = staticmethod(lambda: EnvState.state_input_stderr_log_level_eval_finalized.name)
 
     def _eval_state_once(self) -> ValueType:
-        # TODO: FT_77_15_06_50.dynamic_DAG.md:
-        #       How is it event possible?
-        #       `state_input_stderr_log_level_var_loaded` evaluates recursively `state_input_stderr_log_level_var_loaded`?
         return self.eval_parent_state(EnvState.state_input_stderr_log_level_var_loaded.name)
 
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
 # noinspection PyPep8Naming
 class Factory_state_input_stderr_log_level_eval_finalized(NodeFactory[int]):
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
     def create_state_node(self) -> StateNode[ValueType]:
         if self.env_ctx._is_app:
-            return Bootstrapper_state_input_stderr_log_level_eval_finalized_func_boot_env(self.env_ctx)
+            return Bootstrapper_state_input_stderr_log_level_eval_finalized_is_app(self.env_ctx)
         else:
-            return Bootstrapper_state_input_stderr_log_level_eval_finalized_not_func_boot_env(self.env_ctx)
+            return Bootstrapper_state_input_stderr_log_level_eval_finalized_not_is_app(self.env_ctx)
 
 
 # noinspection PyPep8Naming
@@ -2078,13 +2052,9 @@ class Bootstrapper_state_input_stderr_log_level_handler_configured(AbstractCachi
 
 # noinspection PyPep8Naming
 @conditional_factory
-class Bootstrapper_state_input_sub_command_arg_loaded_func_boot_env(AbstractCachingStateNode[SubCommand]):
+class Bootstrapper_state_input_sub_command_arg_loaded_is_app(AbstractCachingStateNode[SubCommand]):
 
-    _parent_states = staticmethod(
-        lambda: [
-            EnvState.state_args_parsed.name,
-        ]
-    )
+    _parent_states = staticmethod(lambda: [EnvState.state_args_parsed.name])
     _state_name = staticmethod(lambda: EnvState.state_input_sub_command_arg_loaded.name)
 
     def _eval_state_once(self) -> ValueType:
@@ -2097,14 +2067,14 @@ class Bootstrapper_state_input_sub_command_arg_loaded_func_boot_env(AbstractCach
         )
         self.env_ctx._sub_command = state_input_sub_command_arg_loaded
         return state_input_sub_command_arg_loaded
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
 
 # TODO: FT_77_15_06_50.dynamic_DAG.md:
 #       Avoid `arg` in the name (CLI is not available for all use cases).
 # noinspection PyPep8Naming
 @conditional_factory
 class Bootstrapper_state_input_sub_command_arg_loaded_func_start_app(AbstractCachingStateNode[SubCommand]):
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
     _state_name = staticmethod(lambda: EnvState.state_input_sub_command_arg_loaded.name)
 
     def _eval_state_once(self) -> ValueType:
@@ -2119,8 +2089,9 @@ class Bootstrapper_state_input_sub_command_arg_loaded_func_start_app(AbstractCac
 class Bootstrapper_state_input_sub_command_arg_loaded_func_call_lib(AbstractCachingStateNode[SubCommand]):
 
     _state_name = staticmethod(lambda: EnvState.state_input_sub_command_arg_loaded.name)
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
     def _eval_state_once(self) -> ValueType:
+        self.env_ctx._sub_command = None
         return None
 
 
@@ -2128,32 +2099,29 @@ class Bootstrapper_state_input_sub_command_arg_loaded_func_call_lib(AbstractCach
 #       Avoid `arg` in the name (CLI is not available for all use cases).
 # noinspection PyPep8Naming
 class Factory_state_input_sub_command_arg_loaded(NodeFactory[SubCommand]):
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
     def create_state_node(self) -> StateNode[ValueType]:
         if self.env_ctx._is_app:
-            return Bootstrapper_state_input_sub_command_arg_loaded_func_boot_env(self.env_ctx)
+            return Bootstrapper_state_input_sub_command_arg_loaded_is_app(self.env_ctx)
         elif self.env_ctx._entry_func == EntryFunc.func_start_app:
             return Bootstrapper_state_input_sub_command_arg_loaded_func_start_app(self.env_ctx)
-        else:
+        elif self.env_ctx._entry_func == EntryFunc.func_call_lib:
             return Bootstrapper_state_input_sub_command_arg_loaded_func_call_lib(self.env_ctx)
+        else:
+            raise AssertionError(self.env_ctx._entry_func)
 
 
 # noinspection PyPep8Naming
 @conditional_factory
 class Bootstrapper_state_print_conf_finalized_is_app(AbstractCachingStateNode[bool]):
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
-    _parent_states = staticmethod(
-        lambda: [
-            EnvState.state_input_sub_command_arg_loaded.name,
-        ]
-    )
+
+    _parent_states = staticmethod(lambda: [EnvState.state_input_sub_command_arg_loaded.name])
     _state_name = staticmethod(lambda: EnvState.state_print_conf_finalized.name)
 
     def _eval_state_once(self) -> ValueType:
-        sub_cmd: SubCommand = self.eval_parent_state(EnvState.state_input_sub_command_arg_loaded.name)
-        self.env_ctx._print_conf = sub_cmd == SubCommand.command_eval
-        return self.env_ctx._print_conf
-
+        sub_command: SubCommand = self.eval_parent_state(EnvState.state_input_sub_command_arg_loaded.name)
+        return sub_command == SubCommand.command_eval
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
 
 # noinspection PyPep8Naming
 @conditional_factory
@@ -2162,9 +2130,8 @@ class Bootstrapper_state_print_conf_finalized_not_is_app(AbstractCachingStateNod
     _state_name = staticmethod(lambda: EnvState.state_print_conf_finalized.name)
 
     def _eval_state_once(self) -> ValueType:
-        self.env_ctx._print_conf = False
-        return self.env_ctx._print_conf
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+        return False
+
 
 # noinspection PyPep8Naming
 class Factory_state_print_conf_finalized(NodeFactory[bool]):
@@ -2175,18 +2142,14 @@ class Factory_state_print_conf_finalized(NodeFactory[bool]):
         else:
             return Bootstrapper_state_print_conf_finalized_not_is_app(self.env_ctx)
 
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
 # noinspection PyPep8Naming
 @conditional_factory
 class Bootstrapper_state_prepare_venv_finalized_is_app(AbstractCachingStateNode[bool]):
 
-    _parent_states = staticmethod(
-        lambda: [
-            EnvState.state_input_sub_command_arg_loaded.name,
-        ]
-    )
+    _parent_states = staticmethod(lambda: [EnvState.state_input_sub_command_arg_loaded.name])
     _state_name = staticmethod(lambda: EnvState.state_prepare_venv_finalized.name)
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
     def _eval_state_once(self) -> ValueType:
         sub_cmd: SubCommand = self.eval_parent_state(EnvState.state_input_sub_command_arg_loaded.name)
         self.env_ctx._prepare_venv = sub_cmd != SubCommand.command_start
@@ -2202,7 +2165,7 @@ class Bootstrapper_state_prepare_venv_finalized_not_is_app(AbstractCachingStateN
     def _eval_state_once(self) -> ValueType:
         self.env_ctx._prepare_venv = False
         return self.env_ctx._prepare_venv
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
 
 # noinspection PyPep8Naming
 class Factory_state_prepare_venv_finalized(NodeFactory[bool]):
@@ -2212,22 +2175,18 @@ class Factory_state_prepare_venv_finalized(NodeFactory[bool]):
             return Bootstrapper_state_prepare_venv_finalized_is_app(self.env_ctx)
         else:
             return Bootstrapper_state_prepare_venv_finalized_not_is_app(self.env_ctx)
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
 
 # noinspection PyPep8Naming
 @conditional_factory
-class Bootstrapper_state_input_final_state_eval_finalized_func_boot_env(AbstractCachingStateNode[str]):
+class Bootstrapper_state_input_final_state_eval_finalized_is_app(AbstractCachingStateNode[str]):
 
-    _parent_states = staticmethod(
-        lambda: [
-            EnvState.state_args_parsed.name,
-        ]
-    )
+    _parent_states = staticmethod(lambda: [EnvState.state_args_parsed.name])
     _state_name = staticmethod(lambda: EnvState.state_input_final_state_eval_finalized.name)
 
     def _eval_state_once(self) -> ValueType:
         state_args_parsed: argparse.Namespace = self.eval_parent_state(EnvState.state_args_parsed.name)
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
         state_input_final_state_eval_finalized: str | None
         state_input_final_state_eval_finalized = getattr(
             state_args_parsed,
@@ -2235,12 +2194,12 @@ class Bootstrapper_state_input_final_state_eval_finalized_func_boot_env(Abstract
             # NOTE: The value is only set for `SubCommand.command_boot`, otherwise, this default is used:
             None,
         )
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
         if state_input_final_state_eval_finalized is None:
-            if self.env_ctx._final_state is None:
+            if self.env_ctx._forced_final_state is None:
                 state_input_final_state_eval_finalized = TargetState.target_proto_bootstrap_completed.value.name
             else:
-                state_input_final_state_eval_finalized = self.env_ctx._final_state
+                state_input_final_state_eval_finalized = self.env_ctx._forced_final_state
 
         return state_input_final_state_eval_finalized
 
@@ -2248,17 +2207,17 @@ class Bootstrapper_state_input_final_state_eval_finalized_func_boot_env(Abstract
 # noinspection PyPep8Naming
 @conditional_factory
 class Bootstrapper_state_input_final_state_eval_finalized_func_start_app(AbstractCachingStateNode[str]):
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
     _state_name = staticmethod(lambda: EnvState.state_input_final_state_eval_finalized.name)
 
     def _eval_state_once(self) -> ValueType:
         state_input_final_state_eval_finalized: str
-        if self.env_ctx._final_state is None:
+        if self.env_ctx._forced_final_state is None:
             state_input_final_state_eval_finalized = TargetState.target_venv_activated.value.name
         else:
-            state_input_final_state_eval_finalized = self.env_ctx._final_state
+            state_input_final_state_eval_finalized = self.env_ctx._forced_final_state
         return state_input_final_state_eval_finalized
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
 
 # noinspection PyPep8Naming
 @conditional_factory
@@ -2268,12 +2227,12 @@ class Bootstrapper_state_input_final_state_eval_finalized_func_call_lib(Abstract
 
     def _eval_state_once(self) -> ValueType:
         state_input_final_state_eval_finalized: str
-        if self.env_ctx._final_state is None:
+        if self.env_ctx._forced_final_state is None:
             state_input_final_state_eval_finalized = TargetState.target_derived_config_loaded.value.name
         else:
-            state_input_final_state_eval_finalized = self.env_ctx._final_state
+            state_input_final_state_eval_finalized = self.env_ctx._forced_final_state
         return state_input_final_state_eval_finalized
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
 
 # noinspection PyPep8Naming
 class Factory_state_input_final_state_eval_finalized(NodeFactory[StateStride]):
@@ -2283,21 +2242,21 @@ class Factory_state_input_final_state_eval_finalized(NodeFactory[StateStride]):
             EntryFunc.func_boot_env,
             EntryFunc.func_run_main,
         ]:
-            return Bootstrapper_state_input_final_state_eval_finalized_func_boot_env(self.env_ctx)
+            return Bootstrapper_state_input_final_state_eval_finalized_is_app(self.env_ctx)
         elif self.env_ctx._entry_func == EntryFunc.func_start_app:
             return Bootstrapper_state_input_final_state_eval_finalized_func_start_app(self.env_ctx)
         elif self.env_ctx._entry_func == EntryFunc.func_call_lib:
             return Bootstrapper_state_input_final_state_eval_finalized_func_call_lib(self.env_ctx)
         else:
             raise AssertionError(self.env_ctx._entry_func)
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
 
 # noinspection PyPep8Naming
 @trivial_factory
 class Bootstrapper_state_func_boot_env_executed(AbstractCachingStateNode[bool]):
     """
     This is a special node - it traverses ALL nodes for `EntryFunc` cases with parsed args.
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
     BUT: It does not depend on ALL nodes - instead, re-executes the graph with a new target.
     """
 
@@ -2311,7 +2270,7 @@ class Bootstrapper_state_func_boot_env_executed(AbstractCachingStateNode[bool]):
     _state_name = staticmethod(lambda: EnvState.state_func_boot_env_executed.name)
 
     def _eval_state_once(self) -> ValueType:
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
         state_input_sub_command_arg_loaded: SubCommand = self.eval_parent_state(EnvState.state_input_sub_command_arg_loaded.name)
         state_input_final_state_eval_finalized: str = self.eval_parent_state(EnvState.state_input_final_state_eval_finalized.name)
 
@@ -2320,21 +2279,23 @@ class Bootstrapper_state_func_boot_env_executed(AbstractCachingStateNode[bool]):
         selected_strategy: RunStrategy
         if state_input_sub_command_arg_loaded is None:
             raise ValueError(f"sub command is not defined")
-        elif state_input_sub_command_arg_loaded == SubCommand.command_boot:
-            selected_strategy = ExitCodeReporter(self.env_ctx)
-        elif state_input_sub_command_arg_loaded == SubCommand.command_start:
-            selected_strategy = ExitCodeReporter(self.env_ctx)
-        elif state_input_sub_command_arg_loaded == SubCommand.command_reboot:
-            selected_strategy = ExitCodeReporter(self.env_ctx)
         elif state_input_sub_command_arg_loaded == SubCommand.command_eval:
             selected_strategy = ExitCodeReporter(self.env_ctx)
+            # TODO: FT_77_15_06_50.dynamic_DAG.md:
+            #       How does it comply with `EnvContext._forced_final_state`?
             state_node = self.env_ctx._state_graph.get_state_node(EnvState.state_effective_conf_data_printed.name)
+        elif state_input_sub_command_arg_loaded in [
+            SubCommand.command_boot,
+            SubCommand.command_start,
+            SubCommand.command_reboot,
+        ]:
+            selected_strategy = ExitCodeReporter(self.env_ctx)
         else:
             raise ValueError(f"cannot handle sub command [{state_input_sub_command_arg_loaded}]")
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
         selected_strategy.execute_strategy(state_node)
         return True
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
 
 # noinspection PyPep8Naming
 @conditional_factory
@@ -2352,24 +2313,20 @@ class Base_state_func_start_app_executed(AbstractCachingStateNode[bool]):
 # noinspection PyPep8Naming
 @conditional_factory
 class Bootstrapper_state_func_start_app_executed_log_enabled(Base_state_func_start_app_executed):
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
     _parent_states = staticmethod(
         lambda: [
             EnvState.state_input_stderr_log_level_handler_configured.name,
             EnvState.state_input_final_state_eval_finalized.name,
         ]
     )
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
 
 # noinspection PyPep8Naming
 @conditional_factory
 class Bootstrapper_state_func_start_app_executed_log_disabled(Base_state_func_start_app_executed):
 
-    _parent_states = staticmethod(
-        lambda: [
-            EnvState.state_input_final_state_eval_finalized.name,
-        ]
-    )
+    _parent_states = staticmethod(lambda: [EnvState.state_input_final_state_eval_finalized.name])
 
 
 # noinspection PyPep8Naming
@@ -2411,11 +2368,7 @@ class Bootstrapper_state_func_call_lib_executed_log_enabled(Base_state_func_call
 @conditional_factory
 class Bootstrapper_state_func_call_lib_executed_log_disabled(Base_state_func_call_lib_executed):
 
-    _parent_states = staticmethod(
-        lambda: [
-            EnvState.state_input_final_state_eval_finalized.name,
-        ]
-    )
+    _parent_states = staticmethod(lambda: [EnvState.state_input_final_state_eval_finalized.name])
 
 
 # noinspection PyPep8Naming
@@ -2426,12 +2379,12 @@ class Factory_state_func_call_lib_executed(NodeFactory[bool]):
             return Bootstrapper_state_func_call_lib_executed_log_enabled(self.env_ctx)
         else:
             return Bootstrapper_state_func_call_lib_executed_log_disabled(self.env_ctx)
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
 
 # noinspection PyPep8Naming
 @conditional_factory
-class Bootstrapper_state_everything_executed_func_boot_env(AbstractCachingStateNode[bool]):
-
+class Bootstrapper_state_everything_executed_is_app(AbstractCachingStateNode[bool]):
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
     _parent_states = staticmethod(
         lambda: [
             EnvState.state_is_app_defined.name,
@@ -2448,7 +2401,7 @@ class Bootstrapper_state_everything_executed_func_boot_env(AbstractCachingStateN
 # noinspection PyPep8Naming
 @conditional_factory
 class Bootstrapper_state_everything_executed_func_start_app(AbstractCachingStateNode[bool]):
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
     _parent_states = staticmethod(
         lambda: [
             EnvState.state_is_app_defined.name,
@@ -2457,7 +2410,7 @@ class Bootstrapper_state_everything_executed_func_start_app(AbstractCachingState
         ]
     )
     _state_name = staticmethod(lambda: EnvState.state_everything_executed.name)
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
     def _eval_state_once(self) -> ValueType:
         state_func_start_app_executed: bool = self.eval_parent_state(EnvState.state_func_start_app_executed.name)
         return state_func_start_app_executed
@@ -2475,11 +2428,11 @@ class Bootstrapper_state_everything_executed_func_call_lib(AbstractCachingStateN
         ]
     )
     _state_name = staticmethod(lambda: EnvState.state_everything_executed.name)
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
     def _eval_state_once(self) -> ValueType:
         state_func_call_lib_executed: bool = self.eval_parent_state(EnvState.state_func_call_lib_executed.name)
         return state_func_call_lib_executed
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
 
 # noinspection PyPep8Naming
 class Factory_state_everything_executed(NodeFactory[StateStride]):
@@ -2492,15 +2445,15 @@ class Factory_state_everything_executed(NodeFactory[StateStride]):
             EntryFunc.func_boot_env,
             EntryFunc.func_run_main,
         ]:
-            return Bootstrapper_state_everything_executed_func_boot_env(self.env_ctx)
+            return Bootstrapper_state_everything_executed_is_app(self.env_ctx)
         elif self.env_ctx._entry_func == EntryFunc.func_start_app:
             return Bootstrapper_state_everything_executed_func_start_app(self.env_ctx)
         elif self.env_ctx._entry_func == EntryFunc.func_call_lib:
             return Bootstrapper_state_everything_executed_func_call_lib(self.env_ctx)
         else:
             raise AssertionError(self.env_ctx._entry_func)
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
 
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
 # noinspection PyPep8Naming
 @trivial_factory
 class Bootstrapper_state_input_start_id_var_loaded(AbstractCachingStateNode[str]):
@@ -2520,7 +2473,7 @@ class Bootstrapper_state_input_proto_code_file_abs_path_var_loaded(AbstractCachi
     # TODO: TODO_24_49_18_17.fix_proto_code_terms.md: maybe rename both state and implementation to `proto_kernel`?
 
     _state_name = staticmethod(lambda: EnvState.state_input_proto_code_file_abs_path_var_loaded.name)
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
     def _eval_state_once(self) -> ValueType:
         state_input_proto_code_file_abs_path_var_loaded: str | None = os.getenv(
             EnvVar.var_PROTOPRIMER_PROTO_CODE.value,
@@ -2532,7 +2485,7 @@ class Bootstrapper_state_input_proto_code_file_abs_path_var_loaded(AbstractCachi
             if not os.path.isfile(state_input_proto_code_file_abs_path_var_loaded):
                 raise AssertionError(f"file {state_input_proto_code_file_abs_path_var_loaded} is not available")
         return state_input_proto_code_file_abs_path_var_loaded
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
 
 # noinspection PyPep8Naming
 @conditional_factory
@@ -2548,18 +2501,20 @@ class Bootstrapper_state_stride_py_arbitrary_reached_is_app(AbstractCachingState
         ]
     )
     _state_name = staticmethod(lambda: EnvState.state_stride_py_arbitrary_reached.name)
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
     def _eval_state_once(self) -> ValueType:
 
         state_stride_py_arbitrary_reached: StateStride = StateStride.stride_py_arbitrary
 
         state_input_sub_command_arg_loaded: SubCommand = self.eval_parent_state(EnvState.state_input_sub_command_arg_loaded.name)
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
         if self.env_ctx.has_stride_reached(next_stride=state_stride_py_arbitrary_reached):
             return self.env_ctx.set_max_stride(state_stride_py_arbitrary_reached)
 
         if (
             (os.environ.get(EnvVar.var_PROTOPRIMER_PROTO_CODE.value, None) is not None)
+            # TODO: FT_77_15_06_50.dynamic_DAG.md:
+            #       Review and clarify `SubCommand.command_start`, `EnvContext._is_app`, ...
             and state_input_sub_command_arg_loaded == SubCommand.command_start
             #
         ):
@@ -2569,7 +2524,7 @@ class Bootstrapper_state_stride_py_arbitrary_reached_is_app(AbstractCachingState
             return self.env_ctx.set_max_stride(state_stride_py_arbitrary_reached)
 
         state_input_start_id_var_loaded: str = self.eval_parent_state(EnvState.state_input_start_id_var_loaded.name)
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
         log_python_context(logging.DEBUG)
 
         # UC_90_98_17_93.run_under_venv.md
@@ -2577,7 +2532,7 @@ class Bootstrapper_state_stride_py_arbitrary_reached_is_app(AbstractCachingState
         # it might be a wrong one,
         # and even if it is the right one,
         # child states require out of `venv` execution.
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
         cleaned_env = os.environ.copy()
 
         orig_venv_abs_path = cleaned_env.pop(ConfConstInput.ext_env_var_VIRTUAL_ENV, None)
@@ -2594,7 +2549,7 @@ class Bootstrapper_state_stride_py_arbitrary_reached_is_app(AbstractCachingState
             PATH_parts: list[str] = orig_PATH_value.split(os.pathsep)
             cleaned_path_parts = [p for p in PATH_parts if p != venv_bin_abs_path]
             cleaned_env[ConfConstInput.ext_env_var_PATH] = os.pathsep.join(cleaned_path_parts)
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
         path_to_curr_python = get_path_to_curr_python()
         path_to_next_python = get_path_to_base_python()
         return switch_python(
@@ -2605,7 +2560,7 @@ class Bootstrapper_state_stride_py_arbitrary_reached_is_app(AbstractCachingState
             proto_code_abs_file_path=None,
             required_environ=cleaned_env,
         )
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
 
 # noinspection PyPep8Naming
 @conditional_factory
@@ -2617,7 +2572,7 @@ class Bootstrapper_state_stride_py_arbitrary_reached_not_is_app(AbstractCachingS
         # For `func_start_app`: `EnvVar.var_PROTOPRIMER_PROTO_CODE` is set (contract),
         # so it does not need to switch to `StateStride.stride_py_arbitrary` to set it:
         return self.env_ctx.set_max_stride(StateStride.stride_py_arbitrary)
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
 
 # noinspection PyPep8Naming
 class Factory_state_stride_py_arbitrary_reached(NodeFactory[StateStride]):
@@ -2627,7 +2582,7 @@ class Factory_state_stride_py_arbitrary_reached(NodeFactory[StateStride]):
             return Bootstrapper_state_stride_py_arbitrary_reached_is_app(self.env_ctx)
         else:
             return Bootstrapper_state_stride_py_arbitrary_reached_not_is_app(self.env_ctx)
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
 
 # noinspection PyPep8Naming
 @conditional_factory
@@ -2636,11 +2591,11 @@ class Bootstrapper_state_proto_code_file_abs_path_inited_func_call_lib(AbstractC
 
     def _eval_state_once(self) -> ValueType:
         proto_kernel_abs_path: str | None
-        if self.env_ctx._proto_kernel_abs_path is None:
+        if self.env_ctx._forced_proto_kernel_abs_path is None:
             proto_kernel_abs_path = get_proto_kernel_abs_path()
         else:
-            proto_kernel_abs_path = self.env_ctx._proto_kernel_abs_path
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+            proto_kernel_abs_path = self.env_ctx._forced_proto_kernel_abs_path
+
         if proto_kernel_abs_path is None:
             raise AssertionError(f"`proto_kernel_abs_path` [{proto_kernel_abs_path}] is not set")
         if not os.path.isfile(proto_kernel_abs_path):
@@ -2648,7 +2603,7 @@ class Bootstrapper_state_proto_code_file_abs_path_inited_func_call_lib(AbstractC
         assert_proto_kernel_is_stand_alone(proto_kernel_abs_path)
         return proto_kernel_abs_path
 
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
 # noinspection PyPep8Naming
 @conditional_factory
 class Bootstrapper_state_proto_code_file_abs_path_inited_not_func_call_lib(AbstractCachingStateNode[str]):
@@ -2661,7 +2616,7 @@ class Bootstrapper_state_proto_code_file_abs_path_inited_not_func_call_lib(Abstr
     _state_name = staticmethod(lambda: EnvState.state_proto_code_file_abs_path_inited.name)
 
     def _eval_state_once(self) -> ValueType:
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
         state_input_proto_code_file_abs_path_var_loaded: str | None = self.eval_parent_state(EnvState.state_input_proto_code_file_abs_path_var_loaded.name)
 
         assert self.env_ctx.get_stride().value >= StateStride.stride_py_arbitrary.value
@@ -2721,11 +2676,7 @@ class Factory_state_proto_code_file_abs_path_inited(NodeFactory[StateStride]):
 @trivial_factory
 class Bootstrapper_state_primer_conf_file_abs_path_inited(AbstractCachingStateNode[str]):
 
-    _parent_states = staticmethod(
-        lambda: [
-            EnvState.state_proto_code_file_abs_path_inited.name,
-        ]
-    )
+    _parent_states = staticmethod(lambda: [EnvState.state_proto_code_file_abs_path_inited.name])
     _state_name = staticmethod(lambda: EnvState.state_primer_conf_file_abs_path_inited.name)
 ########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
     def _eval_state_once(self) -> ValueType:
@@ -2780,6 +2731,7 @@ class Bootstrapper_state_primer_conf_file_data_loaded(AbstractCachingStateNode[d
     _state_name = staticmethod(lambda: EnvState.state_primer_conf_file_data_loaded.name)
 
     def _eval_state_once(self) -> ValueType:
+        state_print_conf_finalized: bool = self.eval_parent_state(EnvState.state_print_conf_finalized.name)
         state_proto_code_file_abs_path_inited: str = self.eval_parent_state(EnvState.state_proto_code_file_abs_path_inited.name)
         state_primer_conf_file_abs_path_inited: str = self.eval_parent_state(EnvState.state_primer_conf_file_abs_path_inited.name)
 
@@ -2794,7 +2746,7 @@ class Bootstrapper_state_primer_conf_file_data_loaded(AbstractCachingStateNode[d
             )
             file_data = {}
 ########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
-        if can_print_effective_config(self):
+        if _can_print_effective_config(self, state_print_conf_finalized):
 
             # Print `ConfLeap.leap_input` data together:
             # ===
@@ -2933,15 +2885,16 @@ class Bootstrapper_state_client_conf_file_data_loaded(AbstractCachingStateNode[d
 
     _parent_states = staticmethod(
         lambda: [
+            EnvState.state_print_conf_finalized.name,
             EnvState.state_global_conf_file_abs_path_inited.name,
         ]
     )
     _state_name = staticmethod(lambda: EnvState.state_client_conf_file_data_loaded.name)
 
     def _eval_state_once(self) -> ValueType:
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+        state_print_conf_finalized: bool = self.eval_parent_state(EnvState.state_print_conf_finalized.name)
         state_global_conf_file_abs_path_inited: str = self.eval_parent_state(EnvState.state_global_conf_file_abs_path_inited.name)
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
         file_data: dict
         if os.path.exists(state_global_conf_file_abs_path_inited):
             file_data = read_json_file(state_global_conf_file_abs_path_inited)
@@ -2953,7 +2906,7 @@ class Bootstrapper_state_client_conf_file_data_loaded(AbstractCachingStateNode[d
             )
             file_data = {}
 
-        if can_print_effective_config(self):
+        if _can_print_effective_config(self, state_print_conf_finalized):
             print(
                 json.dumps(
                     {
@@ -3056,7 +3009,7 @@ class Base_state_selected_env_dir_rel_path(AbstractCachingStateNode[str]):
 
 # noinspection PyPep8Naming
 @conditional_factory
-class Bootstrapper_state_selected_env_dir_rel_path_inited_func_boot_env(Base_state_selected_env_dir_rel_path):
+class Bootstrapper_state_selected_env_dir_rel_path_inited_is_app(Base_state_selected_env_dir_rel_path):
 
     _parent_states = staticmethod(
         lambda: [
@@ -3080,7 +3033,7 @@ class Bootstrapper_state_selected_env_dir_rel_path_inited_func_boot_env(Base_sta
 
 # noinspection PyPep8Naming
 @conditional_factory
-class Bootstrapper_state_selected_env_dir_rel_path_inited_not_func_boot_env(Base_state_selected_env_dir_rel_path):
+class Bootstrapper_state_selected_env_dir_rel_path_inited_not_is_app(Base_state_selected_env_dir_rel_path):
 
     _parent_states = staticmethod(
         lambda: [
@@ -3099,9 +3052,9 @@ class Factory_state_selected_env_dir_rel_path_inited(NodeFactory[StateStride]):
 
     def create_state_node(self) -> StateNode[ValueType]:
         if self.env_ctx._is_app:
-            return Bootstrapper_state_selected_env_dir_rel_path_inited_func_boot_env(self.env_ctx)
+            return Bootstrapper_state_selected_env_dir_rel_path_inited_is_app(self.env_ctx)
         else:
-            return Bootstrapper_state_selected_env_dir_rel_path_inited_not_func_boot_env(self.env_ctx)
+            return Bootstrapper_state_selected_env_dir_rel_path_inited_not_is_app(self.env_ctx)
 ########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
 
 # noinspection PyPep8Naming
@@ -3208,12 +3161,14 @@ class Bootstrapper_state_env_conf_file_data_loaded(AbstractCachingStateNode[dict
 
     _parent_states = staticmethod(
         lambda: [
+            EnvState.state_print_conf_finalized.name,
             EnvState.state_local_conf_file_abs_path_inited.name,
         ]
     )
     _state_name = staticmethod(lambda: EnvState.state_env_conf_file_data_loaded.name)
 
     def _eval_state_once(self) -> ValueType:
+        state_print_conf_finalized: bool = self.eval_parent_state(EnvState.state_print_conf_finalized.name)
         state_local_conf_file_abs_path_inited: str = self.eval_parent_state(EnvState.state_local_conf_file_abs_path_inited.name)
 ########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
         file_data: dict
@@ -3230,7 +3185,7 @@ class Bootstrapper_state_env_conf_file_data_loaded(AbstractCachingStateNode[dict
                 )
             file_data = {}
 
-        if can_print_effective_config(self):
+        if _can_print_effective_config(self, state_print_conf_finalized):
             print(
                 json.dumps(
                     {
@@ -3631,6 +3586,7 @@ class Bootstrapper_state_derived_conf_data_loaded(AbstractCachingStateNode[dict]
 ########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
         # TODO: Is this needed given the list of dependencies in `derived_data_env_states`?
         parent_states = [
+            EnvState.state_print_conf_finalized.name,
             EnvState.state_primer_conf_file_data_loaded.name,
             EnvState.state_client_conf_file_data_loaded.name,
             EnvState.state_env_conf_file_data_loaded.name,
@@ -3644,7 +3600,7 @@ class Bootstrapper_state_derived_conf_data_loaded(AbstractCachingStateNode[dict]
         super().__init__(env_ctx=env_ctx)
 
     def _eval_state_once(self) -> ValueType:
-
+        state_print_conf_finalized: bool = self.eval_parent_state(EnvState.state_print_conf_finalized.name)
         config_data_derived = {}
         for derived_data_env_state in self.derived_data_env_states:
             evaluated_value = self.eval_parent_state(derived_data_env_state)
@@ -3653,7 +3609,7 @@ class Bootstrapper_state_derived_conf_data_loaded(AbstractCachingStateNode[dict]
             else:
                 config_data_derived[derived_data_env_state] = evaluated_value
 ########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
-        if can_print_effective_config(self):
+        if _can_print_effective_config(self, state_print_conf_finalized):
             print(
                 json.dumps(
                     {
@@ -3673,11 +3629,7 @@ class Bootstrapper_state_effective_conf_data_printed(AbstractCachingStateNode[in
     Implements: FT_19_44_42_19.effective_config.md
     """
 
-    _parent_states = staticmethod(
-        lambda: [
-            EnvState.state_derived_conf_data_loaded.name,
-        ]
-    )
+    _parent_states = staticmethod(lambda: [EnvState.state_derived_conf_data_loaded.name])
     _state_name = staticmethod(lambda: EnvState.state_effective_conf_data_printed.name)
 ########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
     def _eval_state_once(self) -> ValueType:
@@ -3724,7 +3676,7 @@ class Bootstrapper_state_default_file_log_handler_configured(AbstractCachingStat
 ########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
 # noinspection PyPep8Naming
 @conditional_factory
-class Bootstrapper_state_stride_py_required_reached_not_command_start(AbstractCachingStateNode[StateStride]):
+class Bootstrapper_state_stride_py_required_reached_prepare_venv(AbstractCachingStateNode[StateStride]):
     """
     Recursively runs this script inside the `python` interpreter required by the client.
 
@@ -3792,7 +3744,7 @@ class Bootstrapper_state_stride_py_required_reached_not_command_start(AbstractCa
 
 # noinspection PyPep8Naming
 @conditional_factory
-class Bootstrapper_state_stride_py_required_reached_command_start(AbstractCachingStateNode[StateStride]):
+class Bootstrapper_state_stride_py_required_reached_not_prepare_venv(AbstractCachingStateNode[StateStride]):
     _parent_states = staticmethod(
         lambda: [
             EnvState.state_prepare_venv_finalized.name,
@@ -3824,15 +3776,10 @@ class Factory_state_stride_py_required_reached(NodeFactory[StateStride]):
         # The only reason for `EnvState.state_stride_py_required_reached`
         # is to use the required `python` to create a `venv`.
         if self.env_ctx._prepare_venv:
-            # TODO: FT_77_15_06_50.dynamic_DAG.md:
-            #       Rename to avoid `command_start` in its name:
-            return Bootstrapper_state_stride_py_required_reached_not_command_start(self.env_ctx)
+            return Bootstrapper_state_stride_py_required_reached_prepare_venv(self.env_ctx)
         else:
-            # TODO: FT_77_15_06_50.dynamic_DAG.md:
-            #       Rename to avoid `command_start` in its name:
-            # Skip it as `venv` is supposed to be ready:
-            return Bootstrapper_state_stride_py_required_reached_command_start(self.env_ctx)
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+            return Bootstrapper_state_stride_py_required_reached_not_prepare_venv(self.env_ctx)
+
 
 # noinspection PyPep8Naming
 @conditional_factory
@@ -3840,7 +3787,7 @@ class Bootstrapper_state_reboot_triggered_is_app(AbstractCachingStateNode[bool])
     """
     Removes current `venv` dir and `version_constraints.txt` file (to trigger their re-creation subsequently).
     """
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
     _parent_states = staticmethod(
         lambda: [
             EnvState.state_input_sub_command_arg_loaded.name,
@@ -3855,17 +3802,19 @@ class Bootstrapper_state_reboot_triggered_is_app(AbstractCachingStateNode[bool])
         ]
     )
     _state_name = staticmethod(lambda: EnvState.state_reboot_triggered.name)
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
     def _eval_state_once(self) -> ValueType:
 
         state_input_sub_command_arg_loaded: SubCommand = self.eval_parent_state(EnvState.state_input_sub_command_arg_loaded.name)
 
+        # TODO: FT_77_15_06_50.dynamic_DAG.md:
+        #       Review and clarify `SubCommand.command_start`, `EnvContext._is_app`, ...
         if state_input_sub_command_arg_loaded == SubCommand.command_start:
             # The only reason for `EnvState.state_reboot_triggered`
             # is to destroy `venv` to recreate it later.
             # Skip it as `venv` is supposed to be ready in `SubCommand.command_start`:
             return False
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
         state_input_start_id_var_loaded: str = self.eval_parent_state(EnvState.state_input_start_id_var_loaded.name)
 
         reboot_env: bool = state_input_sub_command_arg_loaded == SubCommand.command_reboot
@@ -3876,7 +3825,7 @@ class Bootstrapper_state_reboot_triggered_is_app(AbstractCachingStateNode[bool])
         # Reboot can only happen outside `venv` (to delete it):
         if not (reboot_env and state_stride_py_required_reached == StateStride.stride_py_required):
             return False
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
         state_local_venv_dir_abs_path_inited = self.eval_parent_state(EnvState.state_local_venv_dir_abs_path_inited.name)
         if os.path.exists(state_local_venv_dir_abs_path_inited):
 
@@ -3888,7 +3837,7 @@ class Bootstrapper_state_reboot_triggered_is_app(AbstractCachingStateNode[bool])
                 state_local_tmp_dir_abs_path_inited,
                 f"venv.before.{state_input_start_id_var_loaded}",
             )
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
             logger.info(f"moving `venv` dir from [{state_local_venv_dir_abs_path_inited}] to [{moved_venv_dir}]")
 
             shutil.move(
@@ -3905,14 +3854,14 @@ class Bootstrapper_state_reboot_triggered_is_app(AbstractCachingStateNode[bool])
         if os.path.exists(constraints_txt_path):
             logger.info(f"removing version constraints file [{constraints_txt_path}]")
             os.remove(constraints_txt_path)
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
         return True
 
 
 # noinspection PyPep8Naming
 @conditional_factory
 class Bootstrapper_state_reboot_triggered_not_is_app(AbstractCachingStateNode[bool]):
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
     _state_name = staticmethod(lambda: EnvState.state_reboot_triggered.name)
 
     def _eval_state_once(self) -> ValueType:
@@ -3927,7 +3876,7 @@ class Factory_state_reboot_triggered(NodeFactory[bool]):
             return Bootstrapper_state_reboot_triggered_is_app(self.env_ctx)
         else:
             return Bootstrapper_state_reboot_triggered_not_is_app(self.env_ctx)
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
 
 # noinspection PyPep8Naming
 @conditional_factory
@@ -3944,11 +3893,11 @@ class Bootstrapper_state_venv_driver_prepared_is_app(AbstractCachingStateNode[Ve
         ]
     )
     _state_name = staticmethod(lambda: EnvState.state_venv_driver_prepared.name)
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
     def _eval_state_once(self) -> ValueType:
 
         state_input_sub_command_arg_loaded: SubCommand = self.eval_parent_state(EnvState.state_input_sub_command_arg_loaded.name)
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
         state_required_python_version_inited: str = self.eval_parent_state(EnvState.state_required_python_version_inited.name)
 
         state_selected_python_file_abs_path_inited: str = self.eval_parent_state(EnvState.state_selected_python_file_abs_path_inited.name)
@@ -4049,6 +3998,8 @@ class Bootstrapper_state_stride_py_venv_reached_is_app(AbstractCachingStateNode[
         path_to_curr_python: str = get_path_to_curr_python()
         logger.debug(f"path_to_curr_python: {path_to_curr_python}")
 ########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+        # TODO: FT_77_15_06_50.dynamic_DAG.md:
+        #       Review and clarify `SubCommand.command_start`, `EnvContext._is_app`, ...
         if state_input_sub_command_arg_loaded == SubCommand.command_start:
             # Skip `venv` validation before switch because `SubCommand.command_start` does not switch outside of `venv`:
             pass
@@ -4168,8 +4119,7 @@ class Bootstrapper_state_protoprimer_package_installed_is_app(AbstractCachingSta
         state_input_sub_command_arg_loaded: SubCommand = self.eval_parent_state(EnvState.state_input_sub_command_arg_loaded.name)
 
         # TODO: FT_77_15_06_50.dynamic_DAG.md:
-        #       This is not reachable for `SubCommand.command_start`.
-        #       Command `command_start` will switch to `venv_module:func_name` at `StateStride.stride_py_venv`:
+        #       Review and clarify `SubCommand.command_start`, `EnvContext._is_app`, ...
         if state_input_sub_command_arg_loaded == SubCommand.command_start:
             # The only reason for `EnvState.state_protoprimer_package_installed`
             # is to install dependencies into `venv`.
@@ -4322,8 +4272,7 @@ class Bootstrapper_state_version_constraints_generated_is_app(AbstractCachingSta
         state_input_sub_command_arg_loaded: SubCommand = self.eval_parent_state(EnvState.state_input_sub_command_arg_loaded.name)
 
         # TODO: FT_77_15_06_50.dynamic_DAG.md:
-        #       This is not reachable for `SubCommand.command_start`.
-        #       Command `command_start` will switch to `venv_module:func_name` at `StateStride.stride_py_venv`:
+        #       Review and clarify `SubCommand.command_start`, `EnvContext._is_app`, ...
         if state_input_sub_command_arg_loaded == SubCommand.command_start:
             # The only reason for `EnvState.state_version_constraints_generated`
             # is to re-generate the `version_constraints.txt` file based on `venv`.
@@ -4397,8 +4346,7 @@ class Bootstrapper_state_stride_deps_updated_reached_is_app(AbstractCachingState
         state_input_sub_command_arg_loaded: SubCommand = self.eval_parent_state(EnvState.state_input_sub_command_arg_loaded.name)
 
         # TODO: FT_77_15_06_50.dynamic_DAG.md:
-        #       This is not reachable for `SubCommand.command_start`.
-        #       Command `command_start` will switch to `venv_module:func_name` at `StateStride.stride_py_venv`:
+        #       Review and clarify `SubCommand.command_start`, `EnvContext._is_app`, ...
         if state_input_sub_command_arg_loaded == SubCommand.command_start:
             # The only reason for `EnvState.state_stride_deps_updated_reached`
             # is to make `venv` dependencies effective.
@@ -4474,8 +4422,7 @@ class Bootstrapper_state_proto_code_updated_is_app(AbstractCachingStateNode[bool
         state_input_sub_command_arg_loaded: SubCommand = self.eval_parent_state(EnvState.state_input_sub_command_arg_loaded.name)
 
         # TODO: FT_77_15_06_50.dynamic_DAG.md:
-        #       This is not reachable for `SubCommand.command_start`.
-        #       Command `command_start` will switch to `venv_module:func_name` at `StateStride.stride_py_venv`:
+        #       Review and clarify `SubCommand.command_start`, `EnvContext._is_app`, ...
         if state_input_sub_command_arg_loaded == SubCommand.command_start:
             # The only reason for `EnvState.state_proto_code_updated`
             # is to update sources, but that has to be done in `SubCommand.command_boot`.
@@ -4597,13 +4544,9 @@ class Bootstrapper_state_stride_src_updated_reached(AbstractCachingStateNode[Sta
 
 # noinspection PyPep8Naming
 @conditional_factory
-class Bootstrapper_state_input_command_line_func_boot_env(AbstractCachingStateNode[str]):
+class Bootstrapper_state_input_command_line_is_app(AbstractCachingStateNode[str]):
 ########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
-    _parent_states = staticmethod(
-        lambda: [
-            EnvState.state_args_parsed.name,
-        ]
-    )
+    _parent_states = staticmethod(lambda: [EnvState.state_args_parsed.name])
     _state_name = staticmethod(lambda: EnvState.state_input_command_line.name)
 
     def _eval_state_once(self) -> ValueType:
@@ -4617,22 +4560,22 @@ class Bootstrapper_state_input_command_line_func_boot_env(AbstractCachingStateNo
 
 # noinspection PyPep8Naming
 @conditional_factory
-class Bootstrapper_state_input_command_line_not_func_boot_env(AbstractCachingStateNode[str]):
+class Bootstrapper_state_input_command_line_not_is_app(AbstractCachingStateNode[str]):
 
     _state_name = staticmethod(lambda: EnvState.state_input_command_line.name)
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
     def _eval_state_once(self) -> ValueType:
         return None
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
 
 # noinspection PyPep8Naming
 class Factory_state_input_command_line(NodeFactory[str]):
 
     def create_state_node(self) -> StateNode[ValueType]:
         if self.env_ctx._is_app:
-            return Bootstrapper_state_input_command_line_func_boot_env(self.env_ctx)
+            return Bootstrapper_state_input_command_line_is_app(self.env_ctx)
         else:
-            return Bootstrapper_state_input_command_line_not_func_boot_env(self.env_ctx)
+            return Bootstrapper_state_input_command_line_not_is_app(self.env_ctx)
 
 
 # TODO: FT_77_15_06_50.dynamic_DAG.md:
@@ -4643,7 +4586,7 @@ class Bootstrapper_state_command_executed(AbstractCachingStateNode[int]):
     """
     If `ParsedArg.name_command`, this state replaces the current process with a shell executing the given command.
     """
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
     _parent_states = staticmethod(
         lambda: [
             EnvState.state_local_venv_dir_abs_path_inited.name,
@@ -4653,7 +4596,7 @@ class Bootstrapper_state_command_executed(AbstractCachingStateNode[int]):
         ]
     )
     _state_name = staticmethod(lambda: EnvState.state_command_executed.name)
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
     def _eval_state_once(self) -> ValueType:
 
         assert self.env_ctx.get_stride().value >= StateStride.stride_src_updated.value
@@ -4665,7 +4608,7 @@ class Bootstrapper_state_command_executed(AbstractCachingStateNode[int]):
         state_local_cache_dir_abs_path_inited: str = self.eval_parent_state(EnvState.state_local_cache_dir_abs_path_inited.name)
 
         shell_driver: ShellDriverBase = _get_shell_driver(state_local_cache_dir_abs_path_inited)
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
         return shell_driver.run_shell(
             False,
             command_line,
@@ -4674,7 +4617,7 @@ class Bootstrapper_state_command_executed(AbstractCachingStateNode[int]):
 
 
 ########################################################################################################################
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
 
 class EnvState(enum.Enum):
     """
@@ -4690,13 +4633,13 @@ class EnvState(enum.Enum):
           Currently, this enum class maps "state name" -> "impl class" directly.
           In the future, it may change to "state name" -> "impl factory" instead.
     """
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
     state_input_py_exec_var_loaded = Bootstrapper_state_input_py_exec_var_loaded
 
     state_is_app_defined = Bootstrapper_state_is_app_defined
 
     state_input_is_stderr_log_enabled = Bootstrapper_state_input_is_stderr_log_enabled
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
     state_input_stderr_log_level_var_loaded = Bootstrapper_state_input_stderr_log_level_var_loaded
 
     state_default_stderr_log_handler_configured = Bootstrapper_state_default_stderr_log_handler_configured
@@ -4707,16 +4650,18 @@ class EnvState(enum.Enum):
 
     state_input_stderr_log_level_handler_configured = Bootstrapper_state_input_stderr_log_level_handler_configured
 
+    # TODO: FT_77_15_06_50.dynamic_DAG.md:
+    #       Avoid `arg` in the name (CLI is not available for all use cases).
     state_input_sub_command_arg_loaded = Factory_state_input_sub_command_arg_loaded
 
     state_print_conf_finalized = Factory_state_print_conf_finalized
 
     state_prepare_venv_finalized = Factory_state_prepare_venv_finalized
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
     state_input_final_state_eval_finalized = Factory_state_input_final_state_eval_finalized
 
     state_func_boot_env_executed = Bootstrapper_state_func_boot_env_executed
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
     state_func_start_app_executed = Factory_state_func_start_app_executed
 
     state_func_call_lib_executed = Factory_state_func_call_lib_executed
@@ -4734,10 +4679,10 @@ class EnvState(enum.Enum):
     state_proto_code_file_abs_path_inited = Factory_state_proto_code_file_abs_path_inited
 
     state_primer_conf_file_abs_path_inited = Bootstrapper_state_primer_conf_file_abs_path_inited
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
     # `ConfLeap.leap_primer`:
     state_primer_conf_file_data_loaded = Bootstrapper_state_primer_conf_file_data_loaded
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
     state_ref_root_dir_abs_path_inited = Bootstrapper_state_ref_root_dir_abs_path_inited
 
     state_global_conf_dir_abs_path_inited = Bootstrapper_state_global_conf_dir_abs_path_inited
@@ -4755,12 +4700,12 @@ class EnvState(enum.Enum):
 
     # `ConfLeap.leap_env`:
     state_env_conf_file_data_loaded = Bootstrapper_state_env_conf_file_data_loaded
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
     state_required_python_version_inited = Bootstrapper_required_python_version_inited
 
     # TODO: TODO_41_10_50_01.implement_env_selector.md: What is the FT (feature_topic)?
     state_python_selector_file_abs_path_inited = Bootstrapper_state_python_selector_file_abs_path_inited
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
     state_selected_python_file_abs_path_inited = Bootstrapper_state_selected_python_file_abs_path_inited
 
     # TODO: log, tmp, venv, ... dirs should better be configured at client level:
@@ -4776,13 +4721,13 @@ class EnvState(enum.Enum):
     state_local_cache_dir_abs_path_inited = Bootstrapper_state_local_cache_dir_abs_path_inited
 
     state_venv_driver_inited = Bootstrapper_state_venv_driver_inited
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
     state_version_constraints_file_basename_inited = Bootstrapper_state_version_constraints_file_basename_inited
 
     state_project_descriptors_inited = Bootstrapper_state_project_descriptors_inited
 
     state_install_specs_inited = Bootstrapper_state_install_specs_inited
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
     # `ConfLeap.leap_derived`:
     state_derived_conf_data_loaded = Bootstrapper_state_derived_conf_data_loaded
 
@@ -4799,11 +4744,11 @@ class EnvState(enum.Enum):
 
     # restart: `StateStride.stride_py_required` -> `StateStride.stride_py_venv`:
     state_stride_py_venv_reached = Factory_state_stride_py_venv_reached
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
     state_protoprimer_package_installed = Factory_state_protoprimer_package_installed
 
     state_version_constraints_generated = Factory_state_version_constraints_generated
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
     # restart: `StateStride.stride_py_venv` -> `StateStride.stride_deps_updated`:
     # TODO: rename - "reached" sounds weird (and makes no sense):
     state_stride_deps_updated_reached = Factory_state_stride_deps_updated_reached
@@ -4823,10 +4768,10 @@ class TargetState(enum.Enum):
     """
     Special `EnvState`-s.
     """
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
     # A special state that triggers execution of everything else:
     target_everything_executed = EnvState.state_everything_executed
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
     # FT_85_17_35_21.call_lib.md
     # FT_00_22_19_59.derived_config.md
     target_derived_config_loaded = EnvState.state_derived_conf_data_loaded
@@ -4887,7 +4832,7 @@ class StateGraph:
     def eval_state(
         self,
         state_name: str,
-    ) -> Any:
+    ) -> typing.Any:
         try:
             state_node = self.get_state_node(state_name)
         except KeyError:
@@ -4909,19 +4854,22 @@ class EnvContext:
         that affect what implementation is selected by `NodeFactory`.
         """
 
+        # Must be set on `EnvContext` creation before any `EnvState` evaluation:
         self._entry_func: EntryFunc | None = None
 
-        self._state_stride: StateStride = StateStride.stride_py_unknown
+        # Set by `EnvState.state_input_py_exec_var_loaded`:
+        self._state_stride: StateStride | None = None
 
-        # FT_42_03_79_73.reboot_env.md
+        # Set by `EnvState.state_is_app_defined`:
         # FT_58_74_37_70.boot_vs_start.md
         # FT_62_88_55_10.CLI_compatibility.md
         self._is_app: bool | None = None
 ########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
-        # For example:
+        # Set by `EnvState.state_prepare_venv_finalized`:
+        # Roughly:
         # FT_42_03_79_73.reboot_env.md: True
         # FT_05_08_64_67.start_app.md: False
-        self._prepare_venv: bool = False
+        self._prepare_venv: bool | None = None
 
         # TODO: FT_77_15_06_50.dynamic_DAG.md:
         #       Do not use `_sub_command` directly.
@@ -4929,18 +4877,15 @@ class EnvContext:
         #       (which may also be set based on other input).
         self._sub_command: SubCommand | None = None
 
-        self._print_conf: bool = False
+        # Set by `EnvState.state_input_is_stderr_log_enabled`:
+        self._is_log_enabled: bool | None = None
 
-        self._is_log_enabled: bool = False
-
-        # TODO: FT_77_15_06_50.dynamic_DAG.md: should it even be here?
-        #       In some cases yes, in some cases, it may need to be `None`.
         # This is an override for default (different value depending on `EntryFunc`).
-        self._final_state: str | None = None
+        self._forced_final_state: str | None = None
 
         # This is an override for global `_proto_kernel_abs_path`.
         # Same as `EnvVar.var_PROTOPRIMER_PROTO_CODE`, but for non-restart-able `EntryFunc.func_call_lib`.
-        self._proto_kernel_abs_path: str | None = None
+        self._forced_proto_kernel_abs_path: str | None = None
 ########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
         self._state_graph: StateGraph = self._create_state_graph()
 
@@ -4962,7 +4907,7 @@ class EnvContext:
     def eval_state(
         self,
         state_name: str,
-    ) -> Any:
+    ) -> typing.Any:
         return self._state_graph.eval_state(state_name)
 ########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
     def register_factory(
@@ -4974,6 +4919,7 @@ class EnvContext:
         return self._state_graph.register_factory(state_name, factory_class(self), replace_existing)
 
     def get_stride(self) -> StateStride:
+        assert self._state_stride is not None
         return self._state_stride
 
     def set_max_stride(
@@ -4982,19 +4928,21 @@ class EnvContext:
     ) -> StateStride:
         if not self.has_stride_reached(next_stride):
             self._state_stride = next_stride
+        assert self._state_stride is not None
         log_stride.set(self._state_stride)
         return self._state_stride
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
     def has_stride_reached(
         self,
         next_stride: StateStride,
     ) -> bool:
         """
         `StateStride.value` is monotonically increasing.
-        At most one call to `switch_python` is required at each value.
         """
-        return self.get_stride().value >= next_stride.value
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+        if self._state_stride is None:
+            return False
+        return self._state_stride.value >= next_stride.value
+
     def print_exit_line(
         self,
         exit_code: int,
@@ -5005,7 +4953,7 @@ class EnvContext:
         """
         if type(exit_code) is not int:
             raise AssertionError("`exit_code` must be an `int`")
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
         state_default_stderr_log_handler_configured: logging.Handler = self._state_graph.eval_state(EnvState.state_default_stderr_log_handler_configured.name)
 
         status_name: str
@@ -5022,7 +4970,7 @@ class EnvContext:
             else:
                 status_name = "FAILURE"
                 color_status = f"{TermColor.back_dark_red.value}{TermColor.fore_bright_white.value}"
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
             is_reportable = state_default_stderr_log_handler_configured.level <= logging.CRITICAL
 
         if is_reportable:
@@ -5031,7 +4979,7 @@ class EnvContext:
                 file=sys.stderr,
                 flush=True,
             )
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
 
 class ContextBuilder:
     """
@@ -5041,41 +4989,42 @@ class ContextBuilder:
     def __init__(self):
         self._env_ctx = EnvContext()
 
-    def entry_func(self, value: EntryFunc) -> ContextBuilder:
+    def entry_func(self, value: EntryFunc | None) -> ContextBuilder:
         self._env_ctx._entry_func = value
         return self
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
-    def state_stride(self, value: StateStride) -> ContextBuilder:
+
+    def state_stride(self, value: StateStride | None) -> ContextBuilder:
         self._env_ctx._state_stride = value
         return self
 
-    def is_app(self, value: bool) -> ContextBuilder:
+    def is_app(self, value: bool | None) -> ContextBuilder:
         self._env_ctx._is_app = value
         return self
-
-    def prepare_venv(self, value: bool) -> ContextBuilder:
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+    def prepare_venv(self, value: bool | None) -> ContextBuilder:
         self._env_ctx._prepare_venv = value
         return self
 
-    def sub_command(self, value: SubCommand) -> ContextBuilder:
+    def sub_command(self, value: SubCommand | None) -> ContextBuilder:
         self._env_ctx._sub_command = value
         return self
 
-    def is_log_enabled(self, value: bool) -> ContextBuilder:
+    def is_log_enabled(self, value: bool | None) -> ContextBuilder:
         self._env_ctx._is_log_enabled = value
         return self
 
-    def final_state(self, value: str) -> ContextBuilder:
-        self._env_ctx._final_state = value
+    def forced_final_state(self, value: str | None) -> ContextBuilder:
+        self._env_ctx._forced_final_state = value
         return self
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
-    def proto_kernel_abs_path(self, value: str) -> ContextBuilder:
-        self._env_ctx._proto_kernel_abs_path = value
+
+    def forced_proto_kernel_abs_path(self, value: str | None) -> ContextBuilder:
+        self._env_ctx._forced_proto_kernel_abs_path = value
         return self
 
     def build_context(self) -> EnvContext:
+        assert self._env_ctx._entry_func is not None
         return self._env_ctx
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
 
 class StateStrideFilter(logging.Filter):
     """
@@ -5095,8 +5044,8 @@ class StateStrideFilter(logging.Filter):
         record.state_stride = log_stride.get(StateStride.stride_py_unknown)
         # Do not filter:
         return True
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
 
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
 class UtcTimeFormatter(logging.Formatter):
     """
     Custom formatter with the proper timestamp.
@@ -5372,7 +5321,7 @@ def warn_once_at_state_stride(
         logger.warning(log_message)
 
 
-def can_print_effective_config(state_node: StateNode) -> bool:
+def _can_print_effective_config(state_node: StateNode, state_print_conf_finalized: bool) -> bool:
     """
     See: FT_19_44_42_19.effective_config.md
     """
@@ -5381,7 +5330,7 @@ def can_print_effective_config(state_node: StateNode) -> bool:
         state_node.env_ctx.get_stride()
         # `StateStride.stride_py_arbitrary` ensures that the path to `proto_code` is outside `venv`:
         == StateStride.stride_py_arbitrary
-        and state_node.env_ctx._print_conf
+        and state_print_conf_finalized
     )
 ########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
 
@@ -5631,6 +5580,8 @@ def _replace_multiple_body_in_empty_lines(
 ########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
 
 def assert_proto_kernel_is_stand_alone(proto_kernel_abs_path: str) -> None:
+    import site
+
     normalized_path = os.path.realpath(proto_kernel_abs_path)
 
     package_dirs = site.getsitepackages()
@@ -5693,6 +5644,8 @@ def get_python_version(path_to_python: str) -> tuple[int, int, int]:
     """
     Executes a `python` binary and retrieves its version as a numeric tuple.
     """
+    import ast
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
     cmd_args: list[str] = [
         path_to_python,
         "-c",
@@ -5707,7 +5660,7 @@ def get_python_version(path_to_python: str) -> tuple[int, int, int]:
         isinstance(python_version, tuple)
         and len(python_version) == 3
         and all(isinstance(i, int) for i in python_version)
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+        #
     ), f"invalid `python` version format: {python_version}"
     return python_version
 
@@ -5719,7 +5672,8 @@ def parse_python_version(python_version: str) -> tuple[int, int, int]:
     *   "3.13.4-beta" -> (3.13.4)
     *   "3" -> (3.0.0)
     """
-
+    import re
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
     def _parse_version_int(version_part: str) -> int:
         number_match = re.search(r"\d+", version_part)
         return int(number_match.group()) if number_match else 0
@@ -5728,14 +5682,16 @@ def parse_python_version(python_version: str) -> tuple[int, int, int]:
     version_tuple: tuple[int, int, int] = tuple(_parse_version_int(part) for part in version_parts)
     return version_tuple
 
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
 def import_proto_module(
     proto_module_name: str,
     proto_module_abs_path: str,
-) -> types.ModuleType:
+):
     """
     Import a module from an absolute path.
     """
+    import types
+    import importlib.util
 
     module_spec = importlib.util.spec_from_file_location(
         proto_module_name,
@@ -5746,7 +5702,7 @@ def import_proto_module(
     assert module_spec.loader is not None
     module_spec.loader.exec_module(loaded_proto_module)
     return loaded_proto_module
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
 
 def select_python_file_abs_path(
     required_version: tuple[int, int, int],
@@ -5755,7 +5711,7 @@ def select_python_file_abs_path(
     """
     Run the `python` selector script specified in `ConfField.field_python_selector_file_rel_path`.
     """
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
     # TODO: TODO_41_10_50_01.implement_env_selector.md: What is the FT (feature_topic)?
     # TODO: There is `ConfField.field_python_selector_file_rel_path` - why is there hardcoded `python_selector_module`?
     # TODO: Implement local repo example with `python_selector_module`:
@@ -5770,7 +5726,7 @@ def select_python_file_abs_path(
         python_selector_module,
         SelectorFunc.select_python_file_abs_path.value,
     )
-
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
     logger.debug(f"running `{SelectorFunc.select_python_file_abs_path.value}` from `{proto_module_name}`")
     selected_python_abs_path: str | None = external_select_python_file_abs_path(required_version)
     logger.debug(f"returned `selected_python_abs_path` value [{selected_python_abs_path}]")
@@ -5784,7 +5740,7 @@ def select_python_file_abs_path(
         except (subprocess.CalledProcessError, FileNotFoundError):
             logger.warning(f"`python` in `selected_python_abs_path` [{selected_python_abs_path}] failed without returning its version")
             selected_python_abs_path = None
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+
     return selected_python_abs_path
 
 
@@ -5899,20 +5855,16 @@ def get_config(conf_leap: ConfLeap) -> dict:
     """
     UC_54_26_66_63.lib_access_to_config_data.md:
     Retrieve config data for the specified `conf_leap` as a function call (without the process restarts).
-    See FT_96_50_58_75.context_propagation.md:
-    `_proto_kernel_abs_path` is required to load the config from the right paths.
-    None of `EnvVar.*` can be used to ensure FT_66_02_54_56.context_isolation.md.
 
     TODO: Maybe support proto_kernel_abs_path (default to None) to override _proto_kernel_abs_path?
     """
-########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
-    # NOTE: Assume (no verification) the module is loaded from
-    #       (outside venv, outside local packages, outside global packages):
-    # TODO: FT_77_15_06_50.dynamic_DAG.md:
-    #       It is set to `StateStride.stride_py_arbitrary` even though we do not really know
-    #       whether this python is outside `venv` (what `StateStride.stride_py_arbitrary` is really for).
-    #       But it works for now until we can build different implementation for `get_config` lib call.
 
+    # FT_96_50_58_75.context_propagation.md
+    # Assume (no verification) that `_proto_kernel_abs_path` was set to a stand-alone to load config.
+    # None of `EnvVar.*` can be used to ensure FT_66_02_54_56.context_isolation.md.
+    if False:
+        assert_proto_kernel_is_stand_alone(_proto_kernel_abs_path)
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
     _conf_leap_to_state: dict[ConfLeap, str] = {
         ConfLeap.leap_primer: EnvState.state_primer_conf_file_data_loaded.name,
         ConfLeap.leap_client: EnvState.state_client_conf_file_data_loaded.name,
@@ -5923,9 +5875,14 @@ def get_config(conf_leap: ConfLeap) -> dict:
     if conf_leap not in _conf_leap_to_state:
         raise ValueError(f"Unsupported `ConfLeap` value: {conf_leap}")
 
-    env_ctx = EnvContext()
-    env_ctx._entry_func = EntryFunc.func_call_lib
-    env_ctx._final_state = _conf_leap_to_state[conf_leap]
+    env_ctx = (
+        ContextBuilder()
+        .entry_func(EntryFunc.func_call_lib)
+        .state_stride(StateStride.stride_py_arbitrary)
+        .forced_final_state(_conf_leap_to_state[conf_leap])
+        #
+        .build_context()
+    )
     env_ctx.eval_state(TargetState.target_everything_executed.value.name)
     return env_ctx.eval_state(_conf_leap_to_state[conf_leap])
 ########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
@@ -6012,8 +5969,15 @@ def _start_main(
             # noinspection PyPep8Naming
             imported_EntryFunc = getattr(imported_kernel, EntryFunc.__name__)
             imported_run_process = getattr(imported_kernel, run_process.__name__)
-            env_ctx = imported_EnvContext()
-            env_ctx._entry_func = imported_EntryFunc[entry_func.name]
+            # noinspection PyPep8Naming
+            imported_ContextBuilder = getattr(imported_kernel, ContextBuilder.__name__)
+            env_ctx = (
+                imported_ContextBuilder()
+                .entry_func(imported_EntryFunc[entry_func.name])
+                .state_stride(curr_py_exec)
+########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+                .build_context()
+            )
             imported_run_process(env_ctx)
         elif curr_py_exec.value >= StateStride.stride_py_venv.value and entry_func == EntryFunc.func_start_app:
             venv_module = importlib.import_module(module_name)
@@ -6027,8 +5991,13 @@ def _start_main(
         else:
             # FT_14_52_73_23.primer_runtime.md:
             # Keep running `proto_code`:
-            env_ctx = EnvContext()
-            env_ctx._entry_func = entry_func
+            env_ctx = (
+                ContextBuilder()
+                .entry_func(entry_func)
+                .state_stride(curr_py_exec)
+                #
+                .build_context()
+            )
             run_process(env_ctx)
 ########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
     except ImportError as import_error:
@@ -6048,10 +6017,15 @@ def _start_main(
 
 
 def _proto_main() -> None:
-    env_ctx = EnvContext()
-    env_ctx._entry_func = EntryFunc.func_run_main
-    run_process(env_ctx)
+    env_ctx = (
+        ContextBuilder()
+        #
+        .entry_func(EntryFunc.func_run_main)
 ########### !!!!! GENERATED CONTENT - ANY CHANGES WILL BE LOST !!!!! ###########
+        .build_context()
+    )
+    run_process(env_ctx)
+
 
 if __name__ == "__main__":
     _proto_main()

--- a/doc/feature_topic/FT_77_15_06_50.dynamic_DAG.md
+++ b/doc/feature_topic/FT_77_15_06_50.dynamic_DAG.md
@@ -12,14 +12,15 @@ topic_status: TODO
 The DAG builder constructs sub-graphs based on the current [`GraphCoordinates`][FT_25_62_13_55.entry_func.md].
 
 This eliminates complex `if/else` logic within `EnvState`-s to avoid `python` restarts for specialized
-modes like `start_app` or `get_derived_config`.
+modes like `EntryFunc.func_start_app` or `EntryFunc.func_call_lib`.
 
 For example:
-*   calling `start_app` does not require most of `venv` creation and population steps
-*   calling `get_derived_config` must happen with no `python` restarts
-*   both `start_app` and `get_derived_config` should not process any CLI args (as `env_bootstrapper` does)
+*   calling `EntryFunc.func_start_app` does not require most of `venv` creation and population steps
+*   calling `EntryFunc.func_call_lib` must happen with no `python` restarts
+*   both `EntryFunc.func_start_app` and `EntryFunc.func_call_lib` should not process any CLI args
+*   while `EntryFunc.func_boot_env` should process CLI args, run through `python` restarts, and create `venv`
 
-See also more specific case:
+See also a more specific case:
 [UC_54_26_66_63.lib_access_to_config_data.md][UC_54_26_66_63.lib_access_to_config_data.md]
 
 ## DAG sub-graphs
@@ -86,6 +87,13 @@ though they can be extended in an append-only fashion.
 See [FT_68_54_41_96.state_dependency.md][FT_68_54_41_96.state_dependency.md].
 
 ## Open TODOs
+
+*   TODO: FT_77_15_06_50.dynamic_DAG.md:
+          Rename `GraphCoordinates` to refer to what is currently called `EnvContext`.
+
+*   TODO: FT_77_15_06_50.dynamic_DAG.md:
+          Maybe `Env*` prefix in `EnvContext` and `EnvState` should be removed from such classes
+          and replaced by more meningful.
 
 *   TODO: FT_77_15_06_50.dynamic_DAG.md:
           Phase 2: simplify complex `Bootstrap_*` for specific `GraphCoordinates`-s. Adjust factories.

--- a/src/local_doc/main/local_doc/cmd_boot_env.py
+++ b/src/local_doc/main/local_doc/cmd_boot_env.py
@@ -54,7 +54,7 @@ def customize_env_context():
     env_ctx = (
         ContextBuilder()
         .entry_func(EntryFunc.func_boot_env)
-        .final_state(CustomEnvState.state_hello_world_printed.name)
+        .forced_final_state(CustomEnvState.state_hello_world_printed.name)
         #
         .build_context()
     )

--- a/src/local_repo/main/local_repo/cmd_prime_env.py
+++ b/src/local_repo/main/local_repo/cmd_prime_env.py
@@ -33,7 +33,7 @@ def customize_env_context():
         ContextBuilder()
         .entry_func(EntryFunc.func_boot_env)
         .is_app(True)
-        .final_state(CustomEnvState.state_pre_commit_configured.name)
+        .forced_final_state(CustomEnvState.state_pre_commit_configured.name)
         #
         .build_context()
     )

--- a/src/local_repo/main/local_repo/cmd_print_graph.py
+++ b/src/local_repo/main/local_repo/cmd_print_graph.py
@@ -13,9 +13,7 @@ from local_repo.graph_printer import (
     GraphPrinterTextNested,
 )
 from local_repo.misc_tools.graph_utils import get_transitive_dependencies
-from metaprimer.script_lib import (
-    configure_script,
-)
+from metaprimer.script_lib import configure_script
 from protoprimer.primer_kernel import (
     ContextBuilder,
     EntryFunc,
@@ -63,6 +61,13 @@ def custom_main():
     )
 
 
+def _populate_all_state_nodes(state_graph: StateGraph) -> None:
+    # Nodes enter `state_nodes` only on first access lazily.
+    # Force-instantiate all so any consumer of `state_nodes` sees the full graph.
+    for env_state in EnvState:
+        state_graph.get_state_node(env_state.name)
+
+
 def run_print_graph(
     output_format: OutputFormat,
     output_layout: OutputLayout,
@@ -81,18 +86,15 @@ def run_print_graph(
         ContextBuilder()
         .sub_command(sub_command)
         .entry_func(entry_func)
-        .final_state(target_state.value.name)
+        .is_app(entry_func in [EntryFunc.func_boot_env, EntryFunc.func_run_main])
+        .forced_final_state(target_state.value.name)
         #
         .build_context()
     )
 
-    # Ensure all nodes are initialized (populated into `state_graph.state_nodes`):
-    # TODO: FT_77_15_06_50.dynamic_DAG.md:
-    #       Is this still needed?
-    for env_state in EnvState:
-        env_ctx._state_graph.get_state_node(env_state.name)
+    _populate_all_state_nodes(env_ctx._state_graph)
 
-    state_node: StateNode = env_ctx._state_graph.get_state_node(env_ctx._final_state)
+    state_node: StateNode = env_ctx._state_graph.get_state_node(env_ctx._forced_final_state)
 
     if output_format == OutputFormat.output_mermaid and output_layout != OutputLayout.layout_nested:
         raise ValueError(f"Format `{OutputFormat.output_mermaid.value}` requires layout `{OutputLayout.layout_nested.value}`")

--- a/src/local_repo/test/test_local_repo/test_fast_fat_min_mocked/test_GraphPrinterPython.py
+++ b/src/local_repo/test/test_local_repo/test_fast_fat_min_mocked/test_GraphPrinterPython.py
@@ -55,7 +55,9 @@ def test_print_dag_python_output(
         #
         .entry_func.return_value
         #
-        .final_state.return_value
+        .is_app.return_value
+        #
+        .forced_final_state.return_value
         #
         .build_context.return_value
     )

--- a/src/local_repo/test/test_local_repo/test_fast_fat_min_mocked/test_GraphPrinterTextFlat.py
+++ b/src/local_repo/test/test_local_repo/test_fast_fat_min_mocked/test_GraphPrinterTextFlat.py
@@ -49,7 +49,9 @@ def test_print_dag_flat_output(
         #
         .entry_func.return_value
         #
-        .final_state.return_value
+        .is_app.return_value
+        #
+        .forced_final_state.return_value
         #
         .build_context.return_value
     )

--- a/src/metaprimer/main/metaprimer/__init__.py
+++ b/src/metaprimer/main/metaprimer/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.1.1.dev0"
+__version__ = "0.2.0.dev0"

--- a/src/metaprimer/main/metaprimer/conf_renderer.py
+++ b/src/metaprimer/main/metaprimer/conf_renderer.py
@@ -1897,7 +1897,7 @@ def customize_env_context():
         ContextBuilder()
         .entry_func(EntryFunc.func_boot_env)
         .is_app(True)
-        .final_state(RendererState.state_all_conf_data_rendered.name)
+        .forced_final_state(RendererState.state_all_conf_data_rendered.name)
         #
         .build_context()
     )

--- a/src/metaprimer/pyproject.toml
+++ b/src/metaprimer/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "metaprimer"
-version = "0.1.1.dev0"
+version = "0.2.0.dev0"
 authors = [
     { name = "uvsmtid", email = "uvsmtid@gmail.com" },
 ]

--- a/src/protoprimer/main/protoprimer/primer_kernel.py
+++ b/src/protoprimer/main/protoprimer/primer_kernel.py
@@ -24,51 +24,40 @@
 from __future__ import annotations
 
 import argparse
-import ast
-import atexit
 import contextvars
 import datetime
 import enum
 import importlib
-import importlib.util
 import json
 import logging
 import os
 import pathlib
-import re
 import shlex
 import shutil
-import site
 import subprocess
 import sys
-import types
 import typing
-from typing import (
-    Any,
-    Callable,
-    Generic,
-    MutableMapping,
-    TypeVar,
-)
 
 # The release process ensures that content in this file matches the version below while tagging the release commit
 # (otherwise, if the file comes from a different commit, the version is irrelevant):
-__version__ = "0.12.2.dev0"
+__version__ = "0.13.0.dev0"
 
 logger: logging.Logger = logging.getLogger()
 
 log_stride = contextvars.ContextVar("state_stride")
 
-ValueType = TypeVar("ValueType")
-DataValueType = TypeVar("DataValueType")
+ValueType = typing.TypeVar("ValueType")
+DataValueType = typing.TypeVar("DataValueType")
 
 # FT_96_50_58_75.context_propagation.md:
 # It is only set on `EntryFunc.func_start_app` as default for `EntryFunc.func_call_lib`.
-# `EnvContext._proto_kernel_abs_path` overrides it.
+# `EnvContext._forced_proto_kernel_abs_path` overrides it.
 _proto_kernel_abs_path: str | None = None
 
 
 def run_process(env_ctx: EnvContext) -> None:
+    import atexit
+
     # See UC_10_80_27_57.extend_DAG.md
     try:
         ensure_min_python_version()
@@ -1002,7 +991,7 @@ class ShellType(enum.Enum):
     shell_zsh = "zsh"
 
 
-def remove_protoprimer_env_vars(env_vars: MutableMapping[str, str]) -> None:
+def remove_protoprimer_env_vars(env_vars: typing.MutableMapping[str, str]) -> None:
     """
     FT_66_02_54_56.context_isolation.md
     """
@@ -1652,7 +1641,7 @@ class ExitCodeReporter(RunStrategy):
         But it may not reach all nodes because
         dependencies will be conditionally evaluated by the implementation of those nodes.
         """
-        # NOTE: The `EnvContext._final_state` must return `int` with this strategy:
+        # NOTE: The `EnvContext._forced_final_state` must return `int` with this strategy:
         exit_code: int = self.env_ctx.eval_state(state_node.state_name)
         if type(exit_code) is not int:
             raise AssertionError("`exit_code` must be an `int`")
@@ -1662,7 +1651,7 @@ class ExitCodeReporter(RunStrategy):
 ########################################################################################################################
 
 
-class StateNode(Generic[ValueType]):
+class StateNode(typing.Generic[ValueType]):
     """
     All nodes form a `StateGraph`, which must be a DAG.
     """
@@ -1712,7 +1701,7 @@ class StateNode(Generic[ValueType]):
 
 # FT_84_11_73_28.supported_python_versions.md:
 # With min `python` switched to 3.8, `NodeFactory` can be turned into `typing.Protocol`:
-class NodeFactory(Generic[ValueType]):
+class NodeFactory(typing.Generic[ValueType]):
 
     def __init__(
         self,
@@ -1724,7 +1713,7 @@ class NodeFactory(Generic[ValueType]):
         raise NotImplementedError()
 
 
-StateNodeSubclass = TypeVar("StateNodeSubclass", bound=StateNode)
+StateNodeSubclass = typing.TypeVar("StateNodeSubclass", bound=StateNode)
 
 
 def conditional_factory(state_node_class: type[StateNodeSubclass]) -> type[StateNodeSubclass]:
@@ -1750,8 +1739,8 @@ def trivial_factory(state_node_class: type[StateNodeSubclass]) -> type[NodeFacto
 
 
 class AbstractCachingStateNode(StateNode[ValueType]):
-    _parent_states: Callable[[], list[str]] = staticmethod(lambda: [])
-    _state_name: Callable[[], str]
+    _parent_states: typing.Callable[[], list[str]] = staticmethod(lambda: [])
+    _state_name: typing.Callable[[], str]
 
     def __init__(
         self,
@@ -1847,6 +1836,7 @@ class Bootstrapper_state_is_app_defined(AbstractCachingStateNode[bool]):
 @trivial_factory
 class Bootstrapper_state_input_is_stderr_log_enabled(AbstractCachingStateNode[bool]):
 
+    _parent_states = staticmethod(lambda: [EnvState.state_is_app_defined.name])
     _state_name = staticmethod(lambda: EnvState.state_input_is_stderr_log_enabled.name)
 
     def _eval_state_once(self) -> ValueType:
@@ -1909,11 +1899,7 @@ class Bootstrapper_state_input_stderr_log_level_var_loaded(AbstractCachingStateN
 class Bootstrapper_state_default_stderr_log_handler_configured(AbstractCachingStateNode[logging.Handler]):
     # TODO: UC_81_50_97_17.do_not_reuse_logger.md: Shell we disable configuring loggers for `EntryFunc.func_start_app`?
 
-    _parent_states = staticmethod(
-        lambda: [
-            EnvState.state_input_stderr_log_level_var_loaded.name,
-        ]
-    )
+    _parent_states = staticmethod(lambda: [EnvState.state_input_stderr_log_level_var_loaded.name])
     _state_name = staticmethod(lambda: EnvState.state_default_stderr_log_handler_configured.name)
 
     def _eval_state_once(self) -> ValueType:
@@ -1930,7 +1916,7 @@ class Bootstrapper_state_default_stderr_log_handler_configured(AbstractCachingSt
 
 # noinspection PyPep8Naming
 @conditional_factory
-class Bootstrapper_state_args_parsed_func_boot_env(AbstractCachingStateNode[argparse.Namespace]):
+class Bootstrapper_state_args_parsed_is_app(AbstractCachingStateNode[argparse.Namespace]):
 
     _state_name = staticmethod(lambda: EnvState.state_args_parsed.name)
 
@@ -1938,34 +1924,29 @@ class Bootstrapper_state_args_parsed_func_boot_env(AbstractCachingStateNode[argp
         return parse_args()
 
 
-# TODO: FT_77_15_06_50.dynamic_DAG.md:
-#       Do we still need this? Assert at Factory instead.
 # noinspection PyPep8Naming
 @conditional_factory
-class Bootstrapper_state_args_parsed_not_func_boot_env(AbstractCachingStateNode[argparse.Namespace]):
+class Bootstrapper_state_args_parsed_not_is_app(AbstractCachingStateNode[argparse.Namespace]):
 
     _state_name = staticmethod(lambda: EnvState.state_args_parsed.name)
 
     def _eval_state_once(self) -> ValueType:
-        raise AssertionError(f"`{EnvState.state_args_parsed.name}` must not be evaluated for `{self.env_ctx._entry_func}`")
+        raise AssertionError(f"`{EnvState.state_args_parsed.name}` must not be reachable in this context")
 
 
 # noinspection PyPep8Naming
 class Factory_state_args_parsed(NodeFactory[StateStride]):
 
     def create_state_node(self) -> StateNode[ValueType]:
-        # TODO: FT_77_15_06_50.dynamic_DAG.md:
-        #       This step should not be executed without need to parse args.
-        #       Do not fake args. Just redesign dependency. No?
         if self.env_ctx._is_app:
-            return Bootstrapper_state_args_parsed_func_boot_env(self.env_ctx)
+            return Bootstrapper_state_args_parsed_is_app(self.env_ctx)
         else:
-            return Bootstrapper_state_args_parsed_not_func_boot_env(self.env_ctx)
+            return Bootstrapper_state_args_parsed_not_is_app(self.env_ctx)
 
 
 # noinspection PyPep8Naming
 @conditional_factory
-class Bootstrapper_state_input_stderr_log_level_eval_finalized_func_boot_env(AbstractCachingStateNode[int]):
+class Bootstrapper_state_input_stderr_log_level_eval_finalized_is_app(AbstractCachingStateNode[int]):
 
     _parent_states = staticmethod(
         lambda: [
@@ -2012,19 +1993,12 @@ class Bootstrapper_state_input_stderr_log_level_eval_finalized_func_boot_env(Abs
 
 # noinspection PyPep8Naming
 @conditional_factory
-class Bootstrapper_state_input_stderr_log_level_eval_finalized_not_func_boot_env(AbstractCachingStateNode[int]):
+class Bootstrapper_state_input_stderr_log_level_eval_finalized_not_is_app(AbstractCachingStateNode[int]):
 
-    _parent_states = staticmethod(
-        lambda: [
-            EnvState.state_input_stderr_log_level_var_loaded.name,
-        ]
-    )
+    _parent_states = staticmethod(lambda: [EnvState.state_input_stderr_log_level_var_loaded.name])
     _state_name = staticmethod(lambda: EnvState.state_input_stderr_log_level_eval_finalized.name)
 
     def _eval_state_once(self) -> ValueType:
-        # TODO: FT_77_15_06_50.dynamic_DAG.md:
-        #       How is it event possible?
-        #       `state_input_stderr_log_level_var_loaded` evaluates recursively `state_input_stderr_log_level_var_loaded`?
         return self.eval_parent_state(EnvState.state_input_stderr_log_level_var_loaded.name)
 
 
@@ -2033,9 +2007,9 @@ class Factory_state_input_stderr_log_level_eval_finalized(NodeFactory[int]):
 
     def create_state_node(self) -> StateNode[ValueType]:
         if self.env_ctx._is_app:
-            return Bootstrapper_state_input_stderr_log_level_eval_finalized_func_boot_env(self.env_ctx)
+            return Bootstrapper_state_input_stderr_log_level_eval_finalized_is_app(self.env_ctx)
         else:
-            return Bootstrapper_state_input_stderr_log_level_eval_finalized_not_func_boot_env(self.env_ctx)
+            return Bootstrapper_state_input_stderr_log_level_eval_finalized_not_is_app(self.env_ctx)
 
 
 # noinspection PyPep8Naming
@@ -2078,13 +2052,9 @@ class Bootstrapper_state_input_stderr_log_level_handler_configured(AbstractCachi
 
 # noinspection PyPep8Naming
 @conditional_factory
-class Bootstrapper_state_input_sub_command_arg_loaded_func_boot_env(AbstractCachingStateNode[SubCommand]):
+class Bootstrapper_state_input_sub_command_arg_loaded_is_app(AbstractCachingStateNode[SubCommand]):
 
-    _parent_states = staticmethod(
-        lambda: [
-            EnvState.state_args_parsed.name,
-        ]
-    )
+    _parent_states = staticmethod(lambda: [EnvState.state_args_parsed.name])
     _state_name = staticmethod(lambda: EnvState.state_input_sub_command_arg_loaded.name)
 
     def _eval_state_once(self) -> ValueType:
@@ -2121,6 +2091,7 @@ class Bootstrapper_state_input_sub_command_arg_loaded_func_call_lib(AbstractCach
     _state_name = staticmethod(lambda: EnvState.state_input_sub_command_arg_loaded.name)
 
     def _eval_state_once(self) -> ValueType:
+        self.env_ctx._sub_command = None
         return None
 
 
@@ -2131,28 +2102,25 @@ class Factory_state_input_sub_command_arg_loaded(NodeFactory[SubCommand]):
 
     def create_state_node(self) -> StateNode[ValueType]:
         if self.env_ctx._is_app:
-            return Bootstrapper_state_input_sub_command_arg_loaded_func_boot_env(self.env_ctx)
+            return Bootstrapper_state_input_sub_command_arg_loaded_is_app(self.env_ctx)
         elif self.env_ctx._entry_func == EntryFunc.func_start_app:
             return Bootstrapper_state_input_sub_command_arg_loaded_func_start_app(self.env_ctx)
-        else:
+        elif self.env_ctx._entry_func == EntryFunc.func_call_lib:
             return Bootstrapper_state_input_sub_command_arg_loaded_func_call_lib(self.env_ctx)
+        else:
+            raise AssertionError(self.env_ctx._entry_func)
 
 
 # noinspection PyPep8Naming
 @conditional_factory
 class Bootstrapper_state_print_conf_finalized_is_app(AbstractCachingStateNode[bool]):
 
-    _parent_states = staticmethod(
-        lambda: [
-            EnvState.state_input_sub_command_arg_loaded.name,
-        ]
-    )
+    _parent_states = staticmethod(lambda: [EnvState.state_input_sub_command_arg_loaded.name])
     _state_name = staticmethod(lambda: EnvState.state_print_conf_finalized.name)
 
     def _eval_state_once(self) -> ValueType:
-        sub_cmd: SubCommand = self.eval_parent_state(EnvState.state_input_sub_command_arg_loaded.name)
-        self.env_ctx._print_conf = sub_cmd == SubCommand.command_eval
-        return self.env_ctx._print_conf
+        sub_command: SubCommand = self.eval_parent_state(EnvState.state_input_sub_command_arg_loaded.name)
+        return sub_command == SubCommand.command_eval
 
 
 # noinspection PyPep8Naming
@@ -2162,8 +2130,7 @@ class Bootstrapper_state_print_conf_finalized_not_is_app(AbstractCachingStateNod
     _state_name = staticmethod(lambda: EnvState.state_print_conf_finalized.name)
 
     def _eval_state_once(self) -> ValueType:
-        self.env_ctx._print_conf = False
-        return self.env_ctx._print_conf
+        return False
 
 
 # noinspection PyPep8Naming
@@ -2180,11 +2147,7 @@ class Factory_state_print_conf_finalized(NodeFactory[bool]):
 @conditional_factory
 class Bootstrapper_state_prepare_venv_finalized_is_app(AbstractCachingStateNode[bool]):
 
-    _parent_states = staticmethod(
-        lambda: [
-            EnvState.state_input_sub_command_arg_loaded.name,
-        ]
-    )
+    _parent_states = staticmethod(lambda: [EnvState.state_input_sub_command_arg_loaded.name])
     _state_name = staticmethod(lambda: EnvState.state_prepare_venv_finalized.name)
 
     def _eval_state_once(self) -> ValueType:
@@ -2216,13 +2179,9 @@ class Factory_state_prepare_venv_finalized(NodeFactory[bool]):
 
 # noinspection PyPep8Naming
 @conditional_factory
-class Bootstrapper_state_input_final_state_eval_finalized_func_boot_env(AbstractCachingStateNode[str]):
+class Bootstrapper_state_input_final_state_eval_finalized_is_app(AbstractCachingStateNode[str]):
 
-    _parent_states = staticmethod(
-        lambda: [
-            EnvState.state_args_parsed.name,
-        ]
-    )
+    _parent_states = staticmethod(lambda: [EnvState.state_args_parsed.name])
     _state_name = staticmethod(lambda: EnvState.state_input_final_state_eval_finalized.name)
 
     def _eval_state_once(self) -> ValueType:
@@ -2237,10 +2196,10 @@ class Bootstrapper_state_input_final_state_eval_finalized_func_boot_env(Abstract
         )
 
         if state_input_final_state_eval_finalized is None:
-            if self.env_ctx._final_state is None:
+            if self.env_ctx._forced_final_state is None:
                 state_input_final_state_eval_finalized = TargetState.target_proto_bootstrap_completed.value.name
             else:
-                state_input_final_state_eval_finalized = self.env_ctx._final_state
+                state_input_final_state_eval_finalized = self.env_ctx._forced_final_state
 
         return state_input_final_state_eval_finalized
 
@@ -2253,10 +2212,10 @@ class Bootstrapper_state_input_final_state_eval_finalized_func_start_app(Abstrac
 
     def _eval_state_once(self) -> ValueType:
         state_input_final_state_eval_finalized: str
-        if self.env_ctx._final_state is None:
+        if self.env_ctx._forced_final_state is None:
             state_input_final_state_eval_finalized = TargetState.target_venv_activated.value.name
         else:
-            state_input_final_state_eval_finalized = self.env_ctx._final_state
+            state_input_final_state_eval_finalized = self.env_ctx._forced_final_state
         return state_input_final_state_eval_finalized
 
 
@@ -2268,10 +2227,10 @@ class Bootstrapper_state_input_final_state_eval_finalized_func_call_lib(Abstract
 
     def _eval_state_once(self) -> ValueType:
         state_input_final_state_eval_finalized: str
-        if self.env_ctx._final_state is None:
+        if self.env_ctx._forced_final_state is None:
             state_input_final_state_eval_finalized = TargetState.target_derived_config_loaded.value.name
         else:
-            state_input_final_state_eval_finalized = self.env_ctx._final_state
+            state_input_final_state_eval_finalized = self.env_ctx._forced_final_state
         return state_input_final_state_eval_finalized
 
 
@@ -2283,7 +2242,7 @@ class Factory_state_input_final_state_eval_finalized(NodeFactory[StateStride]):
             EntryFunc.func_boot_env,
             EntryFunc.func_run_main,
         ]:
-            return Bootstrapper_state_input_final_state_eval_finalized_func_boot_env(self.env_ctx)
+            return Bootstrapper_state_input_final_state_eval_finalized_is_app(self.env_ctx)
         elif self.env_ctx._entry_func == EntryFunc.func_start_app:
             return Bootstrapper_state_input_final_state_eval_finalized_func_start_app(self.env_ctx)
         elif self.env_ctx._entry_func == EntryFunc.func_call_lib:
@@ -2320,15 +2279,17 @@ class Bootstrapper_state_func_boot_env_executed(AbstractCachingStateNode[bool]):
         selected_strategy: RunStrategy
         if state_input_sub_command_arg_loaded is None:
             raise ValueError(f"sub command is not defined")
-        elif state_input_sub_command_arg_loaded == SubCommand.command_boot:
-            selected_strategy = ExitCodeReporter(self.env_ctx)
-        elif state_input_sub_command_arg_loaded == SubCommand.command_start:
-            selected_strategy = ExitCodeReporter(self.env_ctx)
-        elif state_input_sub_command_arg_loaded == SubCommand.command_reboot:
-            selected_strategy = ExitCodeReporter(self.env_ctx)
         elif state_input_sub_command_arg_loaded == SubCommand.command_eval:
             selected_strategy = ExitCodeReporter(self.env_ctx)
+            # TODO: FT_77_15_06_50.dynamic_DAG.md:
+            #       How does it comply with `EnvContext._forced_final_state`?
             state_node = self.env_ctx._state_graph.get_state_node(EnvState.state_effective_conf_data_printed.name)
+        elif state_input_sub_command_arg_loaded in [
+            SubCommand.command_boot,
+            SubCommand.command_start,
+            SubCommand.command_reboot,
+        ]:
+            selected_strategy = ExitCodeReporter(self.env_ctx)
         else:
             raise ValueError(f"cannot handle sub command [{state_input_sub_command_arg_loaded}]")
 
@@ -2365,11 +2326,7 @@ class Bootstrapper_state_func_start_app_executed_log_enabled(Base_state_func_sta
 @conditional_factory
 class Bootstrapper_state_func_start_app_executed_log_disabled(Base_state_func_start_app_executed):
 
-    _parent_states = staticmethod(
-        lambda: [
-            EnvState.state_input_final_state_eval_finalized.name,
-        ]
-    )
+    _parent_states = staticmethod(lambda: [EnvState.state_input_final_state_eval_finalized.name])
 
 
 # noinspection PyPep8Naming
@@ -2411,11 +2368,7 @@ class Bootstrapper_state_func_call_lib_executed_log_enabled(Base_state_func_call
 @conditional_factory
 class Bootstrapper_state_func_call_lib_executed_log_disabled(Base_state_func_call_lib_executed):
 
-    _parent_states = staticmethod(
-        lambda: [
-            EnvState.state_input_final_state_eval_finalized.name,
-        ]
-    )
+    _parent_states = staticmethod(lambda: [EnvState.state_input_final_state_eval_finalized.name])
 
 
 # noinspection PyPep8Naming
@@ -2430,7 +2383,7 @@ class Factory_state_func_call_lib_executed(NodeFactory[bool]):
 
 # noinspection PyPep8Naming
 @conditional_factory
-class Bootstrapper_state_everything_executed_func_boot_env(AbstractCachingStateNode[bool]):
+class Bootstrapper_state_everything_executed_is_app(AbstractCachingStateNode[bool]):
 
     _parent_states = staticmethod(
         lambda: [
@@ -2492,7 +2445,7 @@ class Factory_state_everything_executed(NodeFactory[StateStride]):
             EntryFunc.func_boot_env,
             EntryFunc.func_run_main,
         ]:
-            return Bootstrapper_state_everything_executed_func_boot_env(self.env_ctx)
+            return Bootstrapper_state_everything_executed_is_app(self.env_ctx)
         elif self.env_ctx._entry_func == EntryFunc.func_start_app:
             return Bootstrapper_state_everything_executed_func_start_app(self.env_ctx)
         elif self.env_ctx._entry_func == EntryFunc.func_call_lib:
@@ -2560,6 +2513,8 @@ class Bootstrapper_state_stride_py_arbitrary_reached_is_app(AbstractCachingState
 
         if (
             (os.environ.get(EnvVar.var_PROTOPRIMER_PROTO_CODE.value, None) is not None)
+            # TODO: FT_77_15_06_50.dynamic_DAG.md:
+            #       Review and clarify `SubCommand.command_start`, `EnvContext._is_app`, ...
             and state_input_sub_command_arg_loaded == SubCommand.command_start
             #
         ):
@@ -2636,10 +2591,10 @@ class Bootstrapper_state_proto_code_file_abs_path_inited_func_call_lib(AbstractC
 
     def _eval_state_once(self) -> ValueType:
         proto_kernel_abs_path: str | None
-        if self.env_ctx._proto_kernel_abs_path is None:
+        if self.env_ctx._forced_proto_kernel_abs_path is None:
             proto_kernel_abs_path = get_proto_kernel_abs_path()
         else:
-            proto_kernel_abs_path = self.env_ctx._proto_kernel_abs_path
+            proto_kernel_abs_path = self.env_ctx._forced_proto_kernel_abs_path
 
         if proto_kernel_abs_path is None:
             raise AssertionError(f"`proto_kernel_abs_path` [{proto_kernel_abs_path}] is not set")
@@ -2721,11 +2676,7 @@ class Factory_state_proto_code_file_abs_path_inited(NodeFactory[StateStride]):
 @trivial_factory
 class Bootstrapper_state_primer_conf_file_abs_path_inited(AbstractCachingStateNode[str]):
 
-    _parent_states = staticmethod(
-        lambda: [
-            EnvState.state_proto_code_file_abs_path_inited.name,
-        ]
-    )
+    _parent_states = staticmethod(lambda: [EnvState.state_proto_code_file_abs_path_inited.name])
     _state_name = staticmethod(lambda: EnvState.state_primer_conf_file_abs_path_inited.name)
 
     def _eval_state_once(self) -> ValueType:
@@ -2780,6 +2731,7 @@ class Bootstrapper_state_primer_conf_file_data_loaded(AbstractCachingStateNode[d
     _state_name = staticmethod(lambda: EnvState.state_primer_conf_file_data_loaded.name)
 
     def _eval_state_once(self) -> ValueType:
+        state_print_conf_finalized: bool = self.eval_parent_state(EnvState.state_print_conf_finalized.name)
         state_proto_code_file_abs_path_inited: str = self.eval_parent_state(EnvState.state_proto_code_file_abs_path_inited.name)
         state_primer_conf_file_abs_path_inited: str = self.eval_parent_state(EnvState.state_primer_conf_file_abs_path_inited.name)
 
@@ -2794,7 +2746,7 @@ class Bootstrapper_state_primer_conf_file_data_loaded(AbstractCachingStateNode[d
             )
             file_data = {}
 
-        if can_print_effective_config(self):
+        if _can_print_effective_config(self, state_print_conf_finalized):
 
             # Print `ConfLeap.leap_input` data together:
             # ===
@@ -2933,13 +2885,14 @@ class Bootstrapper_state_client_conf_file_data_loaded(AbstractCachingStateNode[d
 
     _parent_states = staticmethod(
         lambda: [
+            EnvState.state_print_conf_finalized.name,
             EnvState.state_global_conf_file_abs_path_inited.name,
         ]
     )
     _state_name = staticmethod(lambda: EnvState.state_client_conf_file_data_loaded.name)
 
     def _eval_state_once(self) -> ValueType:
-
+        state_print_conf_finalized: bool = self.eval_parent_state(EnvState.state_print_conf_finalized.name)
         state_global_conf_file_abs_path_inited: str = self.eval_parent_state(EnvState.state_global_conf_file_abs_path_inited.name)
 
         file_data: dict
@@ -2953,7 +2906,7 @@ class Bootstrapper_state_client_conf_file_data_loaded(AbstractCachingStateNode[d
             )
             file_data = {}
 
-        if can_print_effective_config(self):
+        if _can_print_effective_config(self, state_print_conf_finalized):
             print(
                 json.dumps(
                     {
@@ -3056,7 +3009,7 @@ class Base_state_selected_env_dir_rel_path(AbstractCachingStateNode[str]):
 
 # noinspection PyPep8Naming
 @conditional_factory
-class Bootstrapper_state_selected_env_dir_rel_path_inited_func_boot_env(Base_state_selected_env_dir_rel_path):
+class Bootstrapper_state_selected_env_dir_rel_path_inited_is_app(Base_state_selected_env_dir_rel_path):
 
     _parent_states = staticmethod(
         lambda: [
@@ -3080,7 +3033,7 @@ class Bootstrapper_state_selected_env_dir_rel_path_inited_func_boot_env(Base_sta
 
 # noinspection PyPep8Naming
 @conditional_factory
-class Bootstrapper_state_selected_env_dir_rel_path_inited_not_func_boot_env(Base_state_selected_env_dir_rel_path):
+class Bootstrapper_state_selected_env_dir_rel_path_inited_not_is_app(Base_state_selected_env_dir_rel_path):
 
     _parent_states = staticmethod(
         lambda: [
@@ -3099,9 +3052,9 @@ class Factory_state_selected_env_dir_rel_path_inited(NodeFactory[StateStride]):
 
     def create_state_node(self) -> StateNode[ValueType]:
         if self.env_ctx._is_app:
-            return Bootstrapper_state_selected_env_dir_rel_path_inited_func_boot_env(self.env_ctx)
+            return Bootstrapper_state_selected_env_dir_rel_path_inited_is_app(self.env_ctx)
         else:
-            return Bootstrapper_state_selected_env_dir_rel_path_inited_not_func_boot_env(self.env_ctx)
+            return Bootstrapper_state_selected_env_dir_rel_path_inited_not_is_app(self.env_ctx)
 
 
 # noinspection PyPep8Naming
@@ -3208,12 +3161,14 @@ class Bootstrapper_state_env_conf_file_data_loaded(AbstractCachingStateNode[dict
 
     _parent_states = staticmethod(
         lambda: [
+            EnvState.state_print_conf_finalized.name,
             EnvState.state_local_conf_file_abs_path_inited.name,
         ]
     )
     _state_name = staticmethod(lambda: EnvState.state_env_conf_file_data_loaded.name)
 
     def _eval_state_once(self) -> ValueType:
+        state_print_conf_finalized: bool = self.eval_parent_state(EnvState.state_print_conf_finalized.name)
         state_local_conf_file_abs_path_inited: str = self.eval_parent_state(EnvState.state_local_conf_file_abs_path_inited.name)
 
         file_data: dict
@@ -3230,7 +3185,7 @@ class Bootstrapper_state_env_conf_file_data_loaded(AbstractCachingStateNode[dict
                 )
             file_data = {}
 
-        if can_print_effective_config(self):
+        if _can_print_effective_config(self, state_print_conf_finalized):
             print(
                 json.dumps(
                     {
@@ -3631,6 +3586,7 @@ class Bootstrapper_state_derived_conf_data_loaded(AbstractCachingStateNode[dict]
 
         # TODO: Is this needed given the list of dependencies in `derived_data_env_states`?
         parent_states = [
+            EnvState.state_print_conf_finalized.name,
             EnvState.state_primer_conf_file_data_loaded.name,
             EnvState.state_client_conf_file_data_loaded.name,
             EnvState.state_env_conf_file_data_loaded.name,
@@ -3644,7 +3600,7 @@ class Bootstrapper_state_derived_conf_data_loaded(AbstractCachingStateNode[dict]
         super().__init__(env_ctx=env_ctx)
 
     def _eval_state_once(self) -> ValueType:
-
+        state_print_conf_finalized: bool = self.eval_parent_state(EnvState.state_print_conf_finalized.name)
         config_data_derived = {}
         for derived_data_env_state in self.derived_data_env_states:
             evaluated_value = self.eval_parent_state(derived_data_env_state)
@@ -3653,7 +3609,7 @@ class Bootstrapper_state_derived_conf_data_loaded(AbstractCachingStateNode[dict]
             else:
                 config_data_derived[derived_data_env_state] = evaluated_value
 
-        if can_print_effective_config(self):
+        if _can_print_effective_config(self, state_print_conf_finalized):
             print(
                 json.dumps(
                     {
@@ -3673,11 +3629,7 @@ class Bootstrapper_state_effective_conf_data_printed(AbstractCachingStateNode[in
     Implements: FT_19_44_42_19.effective_config.md
     """
 
-    _parent_states = staticmethod(
-        lambda: [
-            EnvState.state_derived_conf_data_loaded.name,
-        ]
-    )
+    _parent_states = staticmethod(lambda: [EnvState.state_derived_conf_data_loaded.name])
     _state_name = staticmethod(lambda: EnvState.state_effective_conf_data_printed.name)
 
     def _eval_state_once(self) -> ValueType:
@@ -3724,7 +3676,7 @@ class Bootstrapper_state_default_file_log_handler_configured(AbstractCachingStat
 
 # noinspection PyPep8Naming
 @conditional_factory
-class Bootstrapper_state_stride_py_required_reached_not_command_start(AbstractCachingStateNode[StateStride]):
+class Bootstrapper_state_stride_py_required_reached_prepare_venv(AbstractCachingStateNode[StateStride]):
     """
     Recursively runs this script inside the `python` interpreter required by the client.
 
@@ -3792,7 +3744,7 @@ class Bootstrapper_state_stride_py_required_reached_not_command_start(AbstractCa
 
 # noinspection PyPep8Naming
 @conditional_factory
-class Bootstrapper_state_stride_py_required_reached_command_start(AbstractCachingStateNode[StateStride]):
+class Bootstrapper_state_stride_py_required_reached_not_prepare_venv(AbstractCachingStateNode[StateStride]):
     _parent_states = staticmethod(
         lambda: [
             EnvState.state_prepare_venv_finalized.name,
@@ -3824,14 +3776,9 @@ class Factory_state_stride_py_required_reached(NodeFactory[StateStride]):
         # The only reason for `EnvState.state_stride_py_required_reached`
         # is to use the required `python` to create a `venv`.
         if self.env_ctx._prepare_venv:
-            # TODO: FT_77_15_06_50.dynamic_DAG.md:
-            #       Rename to avoid `command_start` in its name:
-            return Bootstrapper_state_stride_py_required_reached_not_command_start(self.env_ctx)
+            return Bootstrapper_state_stride_py_required_reached_prepare_venv(self.env_ctx)
         else:
-            # TODO: FT_77_15_06_50.dynamic_DAG.md:
-            #       Rename to avoid `command_start` in its name:
-            # Skip it as `venv` is supposed to be ready:
-            return Bootstrapper_state_stride_py_required_reached_command_start(self.env_ctx)
+            return Bootstrapper_state_stride_py_required_reached_not_prepare_venv(self.env_ctx)
 
 
 # noinspection PyPep8Naming
@@ -3860,6 +3807,8 @@ class Bootstrapper_state_reboot_triggered_is_app(AbstractCachingStateNode[bool])
 
         state_input_sub_command_arg_loaded: SubCommand = self.eval_parent_state(EnvState.state_input_sub_command_arg_loaded.name)
 
+        # TODO: FT_77_15_06_50.dynamic_DAG.md:
+        #       Review and clarify `SubCommand.command_start`, `EnvContext._is_app`, ...
         if state_input_sub_command_arg_loaded == SubCommand.command_start:
             # The only reason for `EnvState.state_reboot_triggered`
             # is to destroy `venv` to recreate it later.
@@ -4049,6 +3998,8 @@ class Bootstrapper_state_stride_py_venv_reached_is_app(AbstractCachingStateNode[
         path_to_curr_python: str = get_path_to_curr_python()
         logger.debug(f"path_to_curr_python: {path_to_curr_python}")
 
+        # TODO: FT_77_15_06_50.dynamic_DAG.md:
+        #       Review and clarify `SubCommand.command_start`, `EnvContext._is_app`, ...
         if state_input_sub_command_arg_loaded == SubCommand.command_start:
             # Skip `venv` validation before switch because `SubCommand.command_start` does not switch outside of `venv`:
             pass
@@ -4168,8 +4119,7 @@ class Bootstrapper_state_protoprimer_package_installed_is_app(AbstractCachingSta
         state_input_sub_command_arg_loaded: SubCommand = self.eval_parent_state(EnvState.state_input_sub_command_arg_loaded.name)
 
         # TODO: FT_77_15_06_50.dynamic_DAG.md:
-        #       This is not reachable for `SubCommand.command_start`.
-        #       Command `command_start` will switch to `venv_module:func_name` at `StateStride.stride_py_venv`:
+        #       Review and clarify `SubCommand.command_start`, `EnvContext._is_app`, ...
         if state_input_sub_command_arg_loaded == SubCommand.command_start:
             # The only reason for `EnvState.state_protoprimer_package_installed`
             # is to install dependencies into `venv`.
@@ -4322,8 +4272,7 @@ class Bootstrapper_state_version_constraints_generated_is_app(AbstractCachingSta
         state_input_sub_command_arg_loaded: SubCommand = self.eval_parent_state(EnvState.state_input_sub_command_arg_loaded.name)
 
         # TODO: FT_77_15_06_50.dynamic_DAG.md:
-        #       This is not reachable for `SubCommand.command_start`.
-        #       Command `command_start` will switch to `venv_module:func_name` at `StateStride.stride_py_venv`:
+        #       Review and clarify `SubCommand.command_start`, `EnvContext._is_app`, ...
         if state_input_sub_command_arg_loaded == SubCommand.command_start:
             # The only reason for `EnvState.state_version_constraints_generated`
             # is to re-generate the `version_constraints.txt` file based on `venv`.
@@ -4397,8 +4346,7 @@ class Bootstrapper_state_stride_deps_updated_reached_is_app(AbstractCachingState
         state_input_sub_command_arg_loaded: SubCommand = self.eval_parent_state(EnvState.state_input_sub_command_arg_loaded.name)
 
         # TODO: FT_77_15_06_50.dynamic_DAG.md:
-        #       This is not reachable for `SubCommand.command_start`.
-        #       Command `command_start` will switch to `venv_module:func_name` at `StateStride.stride_py_venv`:
+        #       Review and clarify `SubCommand.command_start`, `EnvContext._is_app`, ...
         if state_input_sub_command_arg_loaded == SubCommand.command_start:
             # The only reason for `EnvState.state_stride_deps_updated_reached`
             # is to make `venv` dependencies effective.
@@ -4474,8 +4422,7 @@ class Bootstrapper_state_proto_code_updated_is_app(AbstractCachingStateNode[bool
         state_input_sub_command_arg_loaded: SubCommand = self.eval_parent_state(EnvState.state_input_sub_command_arg_loaded.name)
 
         # TODO: FT_77_15_06_50.dynamic_DAG.md:
-        #       This is not reachable for `SubCommand.command_start`.
-        #       Command `command_start` will switch to `venv_module:func_name` at `StateStride.stride_py_venv`:
+        #       Review and clarify `SubCommand.command_start`, `EnvContext._is_app`, ...
         if state_input_sub_command_arg_loaded == SubCommand.command_start:
             # The only reason for `EnvState.state_proto_code_updated`
             # is to update sources, but that has to be done in `SubCommand.command_boot`.
@@ -4597,13 +4544,9 @@ class Bootstrapper_state_stride_src_updated_reached(AbstractCachingStateNode[Sta
 
 # noinspection PyPep8Naming
 @conditional_factory
-class Bootstrapper_state_input_command_line_func_boot_env(AbstractCachingStateNode[str]):
+class Bootstrapper_state_input_command_line_is_app(AbstractCachingStateNode[str]):
 
-    _parent_states = staticmethod(
-        lambda: [
-            EnvState.state_args_parsed.name,
-        ]
-    )
+    _parent_states = staticmethod(lambda: [EnvState.state_args_parsed.name])
     _state_name = staticmethod(lambda: EnvState.state_input_command_line.name)
 
     def _eval_state_once(self) -> ValueType:
@@ -4617,7 +4560,7 @@ class Bootstrapper_state_input_command_line_func_boot_env(AbstractCachingStateNo
 
 # noinspection PyPep8Naming
 @conditional_factory
-class Bootstrapper_state_input_command_line_not_func_boot_env(AbstractCachingStateNode[str]):
+class Bootstrapper_state_input_command_line_not_is_app(AbstractCachingStateNode[str]):
 
     _state_name = staticmethod(lambda: EnvState.state_input_command_line.name)
 
@@ -4630,9 +4573,9 @@ class Factory_state_input_command_line(NodeFactory[str]):
 
     def create_state_node(self) -> StateNode[ValueType]:
         if self.env_ctx._is_app:
-            return Bootstrapper_state_input_command_line_func_boot_env(self.env_ctx)
+            return Bootstrapper_state_input_command_line_is_app(self.env_ctx)
         else:
-            return Bootstrapper_state_input_command_line_not_func_boot_env(self.env_ctx)
+            return Bootstrapper_state_input_command_line_not_is_app(self.env_ctx)
 
 
 # TODO: FT_77_15_06_50.dynamic_DAG.md:
@@ -4707,6 +4650,8 @@ class EnvState(enum.Enum):
 
     state_input_stderr_log_level_handler_configured = Bootstrapper_state_input_stderr_log_level_handler_configured
 
+    # TODO: FT_77_15_06_50.dynamic_DAG.md:
+    #       Avoid `arg` in the name (CLI is not available for all use cases).
     state_input_sub_command_arg_loaded = Factory_state_input_sub_command_arg_loaded
 
     state_print_conf_finalized = Factory_state_print_conf_finalized
@@ -4887,7 +4832,7 @@ class StateGraph:
     def eval_state(
         self,
         state_name: str,
-    ) -> Any:
+    ) -> typing.Any:
         try:
             state_node = self.get_state_node(state_name)
         except KeyError:
@@ -4909,19 +4854,22 @@ class EnvContext:
         that affect what implementation is selected by `NodeFactory`.
         """
 
+        # Must be set on `EnvContext` creation before any `EnvState` evaluation:
         self._entry_func: EntryFunc | None = None
 
-        self._state_stride: StateStride = StateStride.stride_py_unknown
+        # Set by `EnvState.state_input_py_exec_var_loaded`:
+        self._state_stride: StateStride | None = None
 
-        # FT_42_03_79_73.reboot_env.md
+        # Set by `EnvState.state_is_app_defined`:
         # FT_58_74_37_70.boot_vs_start.md
         # FT_62_88_55_10.CLI_compatibility.md
         self._is_app: bool | None = None
 
-        # For example:
+        # Set by `EnvState.state_prepare_venv_finalized`:
+        # Roughly:
         # FT_42_03_79_73.reboot_env.md: True
         # FT_05_08_64_67.start_app.md: False
-        self._prepare_venv: bool = False
+        self._prepare_venv: bool | None = None
 
         # TODO: FT_77_15_06_50.dynamic_DAG.md:
         #       Do not use `_sub_command` directly.
@@ -4929,18 +4877,15 @@ class EnvContext:
         #       (which may also be set based on other input).
         self._sub_command: SubCommand | None = None
 
-        self._print_conf: bool = False
+        # Set by `EnvState.state_input_is_stderr_log_enabled`:
+        self._is_log_enabled: bool | None = None
 
-        self._is_log_enabled: bool = False
-
-        # TODO: FT_77_15_06_50.dynamic_DAG.md: should it even be here?
-        #       In some cases yes, in some cases, it may need to be `None`.
         # This is an override for default (different value depending on `EntryFunc`).
-        self._final_state: str | None = None
+        self._forced_final_state: str | None = None
 
         # This is an override for global `_proto_kernel_abs_path`.
         # Same as `EnvVar.var_PROTOPRIMER_PROTO_CODE`, but for non-restart-able `EntryFunc.func_call_lib`.
-        self._proto_kernel_abs_path: str | None = None
+        self._forced_proto_kernel_abs_path: str | None = None
 
         self._state_graph: StateGraph = self._create_state_graph()
 
@@ -4962,7 +4907,7 @@ class EnvContext:
     def eval_state(
         self,
         state_name: str,
-    ) -> Any:
+    ) -> typing.Any:
         return self._state_graph.eval_state(state_name)
 
     def register_factory(
@@ -4974,6 +4919,7 @@ class EnvContext:
         return self._state_graph.register_factory(state_name, factory_class(self), replace_existing)
 
     def get_stride(self) -> StateStride:
+        assert self._state_stride is not None
         return self._state_stride
 
     def set_max_stride(
@@ -4982,6 +4928,7 @@ class EnvContext:
     ) -> StateStride:
         if not self.has_stride_reached(next_stride):
             self._state_stride = next_stride
+        assert self._state_stride is not None
         log_stride.set(self._state_stride)
         return self._state_stride
 
@@ -4991,9 +4938,10 @@ class EnvContext:
     ) -> bool:
         """
         `StateStride.value` is monotonically increasing.
-        At most one call to `switch_python` is required at each value.
         """
-        return self.get_stride().value >= next_stride.value
+        if self._state_stride is None:
+            return False
+        return self._state_stride.value >= next_stride.value
 
     def print_exit_line(
         self,
@@ -5041,39 +4989,40 @@ class ContextBuilder:
     def __init__(self):
         self._env_ctx = EnvContext()
 
-    def entry_func(self, value: EntryFunc) -> ContextBuilder:
+    def entry_func(self, value: EntryFunc | None) -> ContextBuilder:
         self._env_ctx._entry_func = value
         return self
 
-    def state_stride(self, value: StateStride) -> ContextBuilder:
+    def state_stride(self, value: StateStride | None) -> ContextBuilder:
         self._env_ctx._state_stride = value
         return self
 
-    def is_app(self, value: bool) -> ContextBuilder:
+    def is_app(self, value: bool | None) -> ContextBuilder:
         self._env_ctx._is_app = value
         return self
 
-    def prepare_venv(self, value: bool) -> ContextBuilder:
+    def prepare_venv(self, value: bool | None) -> ContextBuilder:
         self._env_ctx._prepare_venv = value
         return self
 
-    def sub_command(self, value: SubCommand) -> ContextBuilder:
+    def sub_command(self, value: SubCommand | None) -> ContextBuilder:
         self._env_ctx._sub_command = value
         return self
 
-    def is_log_enabled(self, value: bool) -> ContextBuilder:
+    def is_log_enabled(self, value: bool | None) -> ContextBuilder:
         self._env_ctx._is_log_enabled = value
         return self
 
-    def final_state(self, value: str) -> ContextBuilder:
-        self._env_ctx._final_state = value
+    def forced_final_state(self, value: str | None) -> ContextBuilder:
+        self._env_ctx._forced_final_state = value
         return self
 
-    def proto_kernel_abs_path(self, value: str) -> ContextBuilder:
-        self._env_ctx._proto_kernel_abs_path = value
+    def forced_proto_kernel_abs_path(self, value: str | None) -> ContextBuilder:
+        self._env_ctx._forced_proto_kernel_abs_path = value
         return self
 
     def build_context(self) -> EnvContext:
+        assert self._env_ctx._entry_func is not None
         return self._env_ctx
 
 
@@ -5372,7 +5321,7 @@ def warn_once_at_state_stride(
         logger.warning(log_message)
 
 
-def can_print_effective_config(state_node: StateNode) -> bool:
+def _can_print_effective_config(state_node: StateNode, state_print_conf_finalized: bool) -> bool:
     """
     See: FT_19_44_42_19.effective_config.md
     """
@@ -5381,7 +5330,7 @@ def can_print_effective_config(state_node: StateNode) -> bool:
         state_node.env_ctx.get_stride()
         # `StateStride.stride_py_arbitrary` ensures that the path to `proto_code` is outside `venv`:
         == StateStride.stride_py_arbitrary
-        and state_node.env_ctx._print_conf
+        and state_print_conf_finalized
     )
 
 
@@ -5631,6 +5580,8 @@ def _replace_multiple_body_in_empty_lines(
 
 
 def assert_proto_kernel_is_stand_alone(proto_kernel_abs_path: str) -> None:
+    import site
+
     normalized_path = os.path.realpath(proto_kernel_abs_path)
 
     package_dirs = site.getsitepackages()
@@ -5693,6 +5644,8 @@ def get_python_version(path_to_python: str) -> tuple[int, int, int]:
     """
     Executes a `python` binary and retrieves its version as a numeric tuple.
     """
+    import ast
+
     cmd_args: list[str] = [
         path_to_python,
         "-c",
@@ -5719,6 +5672,7 @@ def parse_python_version(python_version: str) -> tuple[int, int, int]:
     *   "3.13.4-beta" -> (3.13.4)
     *   "3" -> (3.0.0)
     """
+    import re
 
     def _parse_version_int(version_part: str) -> int:
         number_match = re.search(r"\d+", version_part)
@@ -5732,10 +5686,12 @@ def parse_python_version(python_version: str) -> tuple[int, int, int]:
 def import_proto_module(
     proto_module_name: str,
     proto_module_abs_path: str,
-) -> types.ModuleType:
+):
     """
     Import a module from an absolute path.
     """
+    import types
+    import importlib.util
 
     module_spec = importlib.util.spec_from_file_location(
         proto_module_name,
@@ -5899,19 +5855,15 @@ def get_config(conf_leap: ConfLeap) -> dict:
     """
     UC_54_26_66_63.lib_access_to_config_data.md:
     Retrieve config data for the specified `conf_leap` as a function call (without the process restarts).
-    See FT_96_50_58_75.context_propagation.md:
-    `_proto_kernel_abs_path` is required to load the config from the right paths.
-    None of `EnvVar.*` can be used to ensure FT_66_02_54_56.context_isolation.md.
 
     TODO: Maybe support proto_kernel_abs_path (default to None) to override _proto_kernel_abs_path?
     """
 
-    # NOTE: Assume (no verification) the module is loaded from
-    #       (outside venv, outside local packages, outside global packages):
-    # TODO: FT_77_15_06_50.dynamic_DAG.md:
-    #       It is set to `StateStride.stride_py_arbitrary` even though we do not really know
-    #       whether this python is outside `venv` (what `StateStride.stride_py_arbitrary` is really for).
-    #       But it works for now until we can build different implementation for `get_config` lib call.
+    # FT_96_50_58_75.context_propagation.md
+    # Assume (no verification) that `_proto_kernel_abs_path` was set to a stand-alone to load config.
+    # None of `EnvVar.*` can be used to ensure FT_66_02_54_56.context_isolation.md.
+    if False:
+        assert_proto_kernel_is_stand_alone(_proto_kernel_abs_path)
 
     _conf_leap_to_state: dict[ConfLeap, str] = {
         ConfLeap.leap_primer: EnvState.state_primer_conf_file_data_loaded.name,
@@ -5923,9 +5875,14 @@ def get_config(conf_leap: ConfLeap) -> dict:
     if conf_leap not in _conf_leap_to_state:
         raise ValueError(f"Unsupported `ConfLeap` value: {conf_leap}")
 
-    env_ctx = EnvContext()
-    env_ctx._entry_func = EntryFunc.func_call_lib
-    env_ctx._final_state = _conf_leap_to_state[conf_leap]
+    env_ctx = (
+        ContextBuilder()
+        .entry_func(EntryFunc.func_call_lib)
+        .state_stride(StateStride.stride_py_arbitrary)
+        .forced_final_state(_conf_leap_to_state[conf_leap])
+        #
+        .build_context()
+    )
     env_ctx.eval_state(TargetState.target_everything_executed.value.name)
     return env_ctx.eval_state(_conf_leap_to_state[conf_leap])
 
@@ -6012,8 +5969,15 @@ def _start_main(
             # noinspection PyPep8Naming
             imported_EntryFunc = getattr(imported_kernel, EntryFunc.__name__)
             imported_run_process = getattr(imported_kernel, run_process.__name__)
-            env_ctx = imported_EnvContext()
-            env_ctx._entry_func = imported_EntryFunc[entry_func.name]
+            # noinspection PyPep8Naming
+            imported_ContextBuilder = getattr(imported_kernel, ContextBuilder.__name__)
+            env_ctx = (
+                imported_ContextBuilder()
+                .entry_func(imported_EntryFunc[entry_func.name])
+                .state_stride(curr_py_exec)
+                #
+                .build_context()
+            )
             imported_run_process(env_ctx)
         elif curr_py_exec.value >= StateStride.stride_py_venv.value and entry_func == EntryFunc.func_start_app:
             venv_module = importlib.import_module(module_name)
@@ -6027,8 +5991,13 @@ def _start_main(
         else:
             # FT_14_52_73_23.primer_runtime.md:
             # Keep running `proto_code`:
-            env_ctx = EnvContext()
-            env_ctx._entry_func = entry_func
+            env_ctx = (
+                ContextBuilder()
+                .entry_func(entry_func)
+                .state_stride(curr_py_exec)
+                #
+                .build_context()
+            )
             run_process(env_ctx)
 
     except ImportError as import_error:
@@ -6048,8 +6017,13 @@ def _start_main(
 
 
 def _proto_main() -> None:
-    env_ctx = EnvContext()
-    env_ctx._entry_func = EntryFunc.func_run_main
+    env_ctx = (
+        ContextBuilder()
+        #
+        .entry_func(EntryFunc.func_run_main)
+        #
+        .build_context()
+    )
     run_process(env_ctx)
 
 

--- a/src/protoprimer/pyproject.toml
+++ b/src/protoprimer/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "protoprimer"
-version = "0.12.2.dev0"
+version = "0.13.0.dev0"
 
 authors = [
     { name = "uvsmtid", email = "uvsmtid@gmail.com" },

--- a/src/protoprimer/test/test_protoprimer/test_fast_fat_min_mocked/test_dynamic_graph/test_evaluated_state_sets.py
+++ b/src/protoprimer/test/test_protoprimer/test_fast_fat_min_mocked/test_dynamic_graph/test_evaluated_state_sets.py
@@ -150,9 +150,6 @@ class TestEvaluatedStateSets:
             EnvState.state_everything_executed.name,
         ]
 
-        # TODO: TODO_60_63_68_81.refactor_DAG_builder.md
-        #       Add assertions for state_name-s which should or should not be seen in this scenario.
-
         mandatory_state_names = [
             # args:
             EnvState.state_args_parsed.name,
@@ -220,10 +217,8 @@ class TestEvaluatedStateSets:
             EnvState.state_everything_executed.name,
         ]
 
-        # TODO: TODO_60_63_68_81.refactor_DAG_builder.md
-        #       Add assertions for state_name-s which should or should not be seen in this scenario.
-
         mandatory_state_names = [
+            # main:
             EnvState.state_everything_executed.name,
             EnvState.state_func_start_app_executed.name,
             EnvState.state_stride_py_venv_reached.name,
@@ -267,7 +262,7 @@ class TestEvaluatedStateSets:
             env_ctx = _make_tracking_env_ctx(
                 entry_func=EntryFunc.func_call_lib,
             )
-            env_ctx._proto_kernel_abs_path = str(proto_kernel_abs_path)
+            env_ctx._forced_proto_kernel_abs_path = str(proto_kernel_abs_path)
 
             actual_state_names = _eval_and_collect(env_ctx)
 
@@ -275,9 +270,9 @@ class TestEvaluatedStateSets:
             EnvState.state_is_app_defined.name,
             EnvState.state_input_is_stderr_log_enabled.name,
             EnvState.state_input_final_state_eval_finalized.name,
+            EnvState.state_print_conf_finalized.name,
             EnvState.state_proto_code_file_abs_path_inited.name,
             EnvState.state_primer_conf_file_abs_path_inited.name,
-            EnvState.state_print_conf_finalized.name,
             EnvState.state_primer_conf_file_data_loaded.name,
             EnvState.state_ref_root_dir_abs_path_inited.name,
             EnvState.state_global_conf_dir_abs_path_inited.name,
@@ -302,10 +297,8 @@ class TestEvaluatedStateSets:
             EnvState.state_everything_executed.name,
         ]
 
-        # TODO: TODO_60_63_68_81.refactor_DAG_builder.md
-        #       Add assertions for state_name-s which should or should not be seen in this scenario.
-
         mandatory_state_names = [
+            # main:
             EnvState.state_everything_executed.name,
             EnvState.state_func_call_lib_executed.name,
             EnvState.state_derived_conf_data_loaded.name,

--- a/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_func_simple/test_proto_main.py
+++ b/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_func_simple/test_proto_main.py
@@ -21,7 +21,7 @@ def test_relationship():
     )
 
 
-@patch(f"{protoprimer.primer_kernel.__name__}.atexit.register")
+@patch("atexit.register")
 @patch(f"{protoprimer.primer_kernel.__name__}.EnvContext")
 @patch(f"{protoprimer.primer_kernel.__name__}.ensure_min_python_version")
 def test_main_success(
@@ -46,7 +46,7 @@ def test_main_success(
     mock_atexit_register.assert_called_once()
 
 
-@patch(f"{protoprimer.primer_kernel.__name__}.atexit.register")
+@patch("atexit.register")
 @patch(f"{protoprimer.primer_kernel.__name__}.EnvContext")
 @patch(f"{protoprimer.primer_kernel.__name__}.ensure_min_python_version")
 def test_main_assertion_error(
@@ -72,7 +72,7 @@ def test_main_assertion_error(
     mock_atexit_register.assert_called_once()
 
 
-@patch(f"{protoprimer.primer_kernel.__name__}.atexit.register")
+@patch("atexit.register")
 @patch(f"{protoprimer.primer_kernel.__name__}.EnvContext")
 @patch(f"{protoprimer.primer_kernel.__name__}.ensure_min_python_version")
 def test_main_system_exit(
@@ -98,7 +98,7 @@ def test_main_system_exit(
     mock_atexit_register.assert_called_once()
 
 
-@patch(f"{protoprimer.primer_kernel.__name__}.atexit.register")
+@patch("atexit.register")
 @patch(f"{protoprimer.primer_kernel.__name__}.EnvContext")
 @patch(f"{protoprimer.primer_kernel.__name__}.ensure_min_python_version")
 def test_main_generic_exception(
@@ -124,7 +124,7 @@ def test_main_generic_exception(
     mock_atexit_register.assert_called_once()
 
 
-@patch(f"{protoprimer.primer_kernel.__name__}.atexit.register")
+@patch("atexit.register")
 @patch(f"{protoprimer.primer_kernel.__name__}.ensure_min_python_version")
 def test_main_with_configure_env_context(
     mock_ensure_min_python_version,
@@ -148,7 +148,7 @@ def test_main_with_configure_env_context(
     mock_atexit_register.assert_called_once()
 
 
-@patch(f"{protoprimer.primer_kernel.__name__}.atexit.register")
+@patch("atexit.register")
 @patch(f"{protoprimer.primer_kernel.__name__}.EnvContext")
 @patch(f"{protoprimer.primer_kernel.__name__}.ensure_min_python_version")
 def test_main_atexit_on_success(
@@ -173,7 +173,7 @@ def test_main_atexit_on_success(
     mock_env_ctx_instance.print_exit_line.assert_called_once_with(0)
 
 
-@patch(f"{protoprimer.primer_kernel.__name__}.atexit.register")
+@patch("atexit.register")
 @patch(f"{protoprimer.primer_kernel.__name__}.EnvContext")
 @patch(f"{protoprimer.primer_kernel.__name__}.ensure_min_python_version")
 def test_main_system_exit_0(
@@ -199,7 +199,7 @@ def test_main_system_exit_0(
     mock_env_ctx_instance.print_exit_line.assert_called_once_with(0)
 
 
-@patch(f"{protoprimer.primer_kernel.__name__}.atexit.register")
+@patch("atexit.register")
 @patch(f"{protoprimer.primer_kernel.__name__}.EnvContext")
 @patch(f"{protoprimer.primer_kernel.__name__}.ensure_min_python_version")
 def test_main_system_exit_none(
@@ -228,7 +228,7 @@ def test_main_system_exit_none(
 _failing_exit_code = 42
 
 
-@patch(f"{protoprimer.primer_kernel.__name__}.atexit.register")
+@patch("atexit.register")
 @patch(f"{protoprimer.primer_kernel.__name__}.EnvContext")
 @patch(f"{protoprimer.primer_kernel.__name__}.ensure_min_python_version")
 def test_called_process_error_raises_runtime_error(
@@ -259,7 +259,7 @@ def test_called_process_error_raises_runtime_error(
     mock_env_ctx_instance.print_exit_line.assert_called_once_with(1)
 
 
-@patch(f"{protoprimer.primer_kernel.__name__}.atexit.register")
+@patch("atexit.register")
 @patch(f"{protoprimer.primer_kernel.__name__}.EnvContext")
 @patch(f"{protoprimer.primer_kernel.__name__}.ensure_min_python_version")
 def test_called_process_error_with_shell_string_raises_runtime_error(

--- a/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_client_conf_file_data_loaded.py
+++ b/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_client_conf_file_data_loaded.py
@@ -12,8 +12,11 @@ from protoprimer import primer_kernel
 from protoprimer.primer_kernel import (
     Bootstrapper_state_global_conf_file_abs_path_inited,
     ConfConstPrimer,
+    ContextBuilder,
+    EntryFunc,
     EnvContext,
     EnvState,
+    Factory_state_print_conf_finalized,
     StateStride,
 )
 
@@ -23,16 +26,28 @@ class ThisTestClass(BasePyfakefsTestClass):
 
     def setUp(self):
         self.setUpPyfakefs()
-        self.env_ctx = EnvContext()
+        self.env_ctx = (
+            ContextBuilder()
+            #
+            .entry_func(EntryFunc.func_boot_env)
+            #
+            .is_app(True)
+            #
+            .state_stride(StateStride.stride_py_unknown)
+            #
+            .build_context()
+        )
 
     # noinspection PyMethodMayBeStatic
     def test_relationship(self):
         assert_test_module_name_embeds_str(EnvState.state_client_conf_file_data_loaded.name)
 
+    @patch(f"{primer_kernel.__name__}.{Factory_state_print_conf_finalized.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_global_conf_file_abs_path_inited.__name__}.create_state_node")
     def test_state_global_conf_file_abs_path_inited_exists(
         self,
         mock_factory_global_conf_file_abs_path_inited,
+        mock_state_print_conf_finalized,
     ):
 
         # given:
@@ -64,15 +79,27 @@ class ThisTestClass(BasePyfakefsTestClass):
 
         # no exception happens
 
-    @patch(f"{primer_kernel.__name__}.EnvContext.get_stride")
+    @patch(f"{primer_kernel.__name__}.{Factory_state_print_conf_finalized.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_global_conf_file_abs_path_inited.__name__}.create_state_node")
     def test_state_global_conf_file_abs_path_inited_missing(
         self,
         mock_factory_global_conf_file_abs_path_inited,
-        mock_get_stride,
+        mock_state_print_conf_finalized,
     ):
 
         # given:
+
+        self.env_ctx = (
+            ContextBuilder()
+            #
+            .entry_func(EntryFunc.func_boot_env)
+            #
+            .is_app(True)
+            #
+            .state_stride(StateStride.stride_py_arbitrary)
+            #
+            .build_context()
+        )
 
         assert_parent_factories_mocked(
             self.env_ctx,
@@ -89,7 +116,6 @@ class ThisTestClass(BasePyfakefsTestClass):
         mock_factory_global_conf_file_abs_path_inited.return_value.eval_own_state.return_value = state_global_conf_file_abs_path_inited
 
         self.assertFalse(os.path.isfile(state_global_conf_file_abs_path_inited))
-        mock_get_stride.return_value = StateStride.stride_py_arbitrary
 
         # when:
 

--- a/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_env_conf_file_data_loaded.py
+++ b/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_env_conf_file_data_loaded.py
@@ -13,8 +13,11 @@ from local_test.name_assertion import assert_test_module_name_embeds_str
 from protoprimer import primer_kernel
 from protoprimer.primer_kernel import (
     Bootstrapper_state_local_conf_file_abs_path_inited,
+    ContextBuilder,
+    EntryFunc,
     EnvContext,
     EnvState,
+    Factory_state_print_conf_finalized,
     StateStride,
 )
 
@@ -24,16 +27,28 @@ class ThisTestClass(BasePyfakefsTestClass):
 
     def setUp(self):
         self.setUpPyfakefs()
-        self.env_ctx = EnvContext()
+        self.env_ctx = (
+            ContextBuilder()
+            #
+            .entry_func(EntryFunc.func_boot_env)
+            #
+            .is_app(True)
+            #
+            .state_stride(StateStride.stride_py_unknown)
+            #
+            .build_context()
+        )
 
     # noinspection PyMethodMayBeStatic
     def test_relationship(self):
         assert_test_module_name_embeds_str(EnvState.state_env_conf_file_data_loaded.name)
 
+    @patch(f"{primer_kernel.__name__}.{Factory_state_print_conf_finalized.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_conf_file_abs_path_inited.__name__}.create_state_node")
     def test_state_env_conf_file_data_loaded_exists(
         self,
         mock_state_local_conf_file_abs_path_inited,
+        mock_state_print_conf_finalized,
     ):
 
         # given:
@@ -57,10 +72,12 @@ class ThisTestClass(BasePyfakefsTestClass):
 
         self.assertEqual(state_value, mock_data)
 
+    @patch(f"{primer_kernel.__name__}.{Factory_state_print_conf_finalized.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_conf_file_abs_path_inited.__name__}.create_state_node")
     def test_state_env_conf_file_data_loaded_missing(
         self,
         mock_state_local_conf_file_abs_path_inited,
+        mock_state_print_conf_finalized,
     ):
 
         # given:
@@ -90,10 +107,12 @@ class ThisTestClass(BasePyfakefsTestClass):
         self.assertEqual({}, state_value)
         self.assertNotIn("does not exist", log_stream.getvalue())
 
+    @patch(f"{primer_kernel.__name__}.{Factory_state_print_conf_finalized.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_local_conf_file_abs_path_inited.__name__}.create_state_node")
     def test_state_env_conf_file_data_loaded_malformed(
         self,
         mock_state_local_conf_file_abs_path_inited,
+        mock_state_print_conf_finalized,
     ):
 
         # given:

--- a/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_func_boot_env_executed.py
+++ b/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_func_boot_env_executed.py
@@ -28,6 +28,8 @@ def env_ctx():
         #
         .entry_func(EntryFunc.func_boot_env)
         #
+        .is_app(True)
+        #
         .build_context()
     )
 

--- a/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_primer_conf_file_data_loaded.py
+++ b/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_primer_conf_file_data_loaded.py
@@ -10,6 +10,8 @@ from local_test.name_assertion import assert_test_module_name_embeds_str
 from protoprimer import primer_kernel
 from protoprimer.primer_kernel import (
     Bootstrapper_state_primer_conf_file_abs_path_inited,
+    ContextBuilder,
+    EntryFunc,
     Factory_state_print_conf_finalized,
     Factory_state_proto_code_file_abs_path_inited,
     EnvContext,
@@ -23,7 +25,17 @@ class ThisTestClass(BasePyfakefsTestClass):
 
     def setUp(self):
         self.setUpPyfakefs()
-        self.env_ctx = EnvContext()
+        self.env_ctx = (
+            ContextBuilder()
+            #
+            .entry_func(EntryFunc.func_boot_env)
+            #
+            .is_app(True)
+            #
+            .state_stride(StateStride.stride_py_arbitrary)
+            #
+            .build_context()
+        )
 
     # noinspection PyMethodMayBeStatic
     def test_relationship(self):
@@ -48,6 +60,7 @@ class ThisTestClass(BasePyfakefsTestClass):
 
         mock_file_path = "/mock/path/to/file"
         mock_state_primer_conf_file_abs_path_inited.return_value.eval_own_state.return_value = mock_file_path
+        mock_state_print_conf_finalized.return_value.eval_own_state.return_value = False
         self.fs.create_file(mock_file_path, contents=json.dumps({"test": "data"}))
 
         # when:
@@ -58,7 +71,6 @@ class ThisTestClass(BasePyfakefsTestClass):
 
         self.assertEqual(state_value, {"test": "data"})
 
-    @patch(f"{primer_kernel.__name__}.EnvContext.get_stride")
     @patch(f"{primer_kernel.__name__}.{Factory_state_print_conf_finalized.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Factory_state_proto_code_file_abs_path_inited.__name__}.create_state_node")
     @patch(f"{primer_kernel.__name__}.{Bootstrapper_state_primer_conf_file_abs_path_inited.__name__}.create_state_node")
@@ -67,7 +79,6 @@ class ThisTestClass(BasePyfakefsTestClass):
         mock_state_primer_conf_file_abs_path_inited,
         mock_state_proto_code_file_abs_path_inited,
         mock_state_print_conf_finalized,
-        mock_get_stride,
     ):
 
         # given:
@@ -80,7 +91,7 @@ class ThisTestClass(BasePyfakefsTestClass):
         mock_file_path = "/mock/path/to/file"
         self.fs.create_dir("/mock/path/to")
         mock_state_primer_conf_file_abs_path_inited.return_value.eval_own_state.return_value = mock_file_path
-        mock_get_stride.return_value = StateStride.stride_py_arbitrary
+        mock_state_print_conf_finalized.return_value.eval_own_state.return_value = False
 
         # when:
 

--- a/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_proto_code_updated.py
+++ b/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_proto_code_updated.py
@@ -13,6 +13,7 @@ from protoprimer.primer_kernel import (
     Factory_state_stride_deps_updated_reached,
     ConfConstGeneral,
     ContextBuilder,
+    EntryFunc,
     EnvContext,
     EnvState,
     SubCommand,
@@ -28,6 +29,8 @@ class ThisTestClass(BasePyfakefsTestClass):
         self.setUpPyfakefs()
         self.env_ctx = (
             ContextBuilder()
+            #
+            .entry_func(EntryFunc.func_boot_env)
             #
             .is_app(True)
             #

--- a/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_protoprimer_package_installed.py
+++ b/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_protoprimer_package_installed.py
@@ -19,6 +19,7 @@ from protoprimer.primer_kernel import (
     ConfConstClient,
     ConfField,
     ContextBuilder,
+    EntryFunc,
     EnvContext,
     EnvState,
     EnvVar,
@@ -35,6 +36,8 @@ class ThisTestClass(BasePyfakefsTestClass):
         self.setUpPyfakefs()
         self.env_ctx = (
             ContextBuilder()
+            #
+            .entry_func(EntryFunc.func_boot_env)
             #
             .is_app(True)
             #

--- a/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_reboot_triggered.py
+++ b/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_reboot_triggered.py
@@ -16,6 +16,7 @@ from protoprimer.primer_kernel import (
     Bootstrapper_state_local_venv_dir_abs_path_inited,
     Bootstrapper_state_version_constraints_file_basename_inited,
     ContextBuilder,
+    EntryFunc,
     Factory_state_prepare_venv_finalized,
     Factory_state_proto_code_file_abs_path_inited,
     Factory_state_stride_py_required_reached,
@@ -32,6 +33,8 @@ from protoprimer.primer_kernel import (
 def env_ctx():
     return (
         ContextBuilder()
+        #
+        .entry_func(EntryFunc.func_boot_env)
         #
         .is_app(True)
         #

--- a/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_stride_deps_updated_reached.py
+++ b/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_stride_deps_updated_reached.py
@@ -12,6 +12,7 @@ from protoprimer.primer_kernel import (
     Factory_state_proto_code_file_abs_path_inited,
     Factory_state_version_constraints_generated,
     ContextBuilder,
+    EntryFunc,
     EnvState,
     SubCommand,
     StateStride,
@@ -24,6 +25,8 @@ from protoprimer.primer_kernel import (
 def env_ctx():
     return (
         ContextBuilder()
+        #
+        .entry_func(EntryFunc.func_boot_env)
         #
         .is_app(True)
         #

--- a/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_stride_py_arbitrary_reached.py
+++ b/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_stride_py_arbitrary_reached.py
@@ -13,6 +13,7 @@ from protoprimer.primer_kernel import (
     Bootstrapper_state_input_start_id_var_loaded,
     ConfConstInput,
     ContextBuilder,
+    EntryFunc,
     EnvState,
     StateStride,
 )
@@ -22,6 +23,8 @@ from protoprimer.primer_kernel import (
 def env_ctx():
     return (
         ContextBuilder()
+        #
+        .entry_func(EntryFunc.func_boot_env)
         #
         .is_app(True)
         #

--- a/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_stride_py_required_reached.py
+++ b/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_stride_py_required_reached.py
@@ -20,6 +20,8 @@ from protoprimer.primer_kernel import (
     Factory_state_input_sub_command_arg_loaded,
     ConfConstEnv,
     ConfConstGeneral,
+    ContextBuilder,
+    EntryFunc,
     EnvContext,
     EnvState,
     StateStride,
@@ -42,7 +44,17 @@ class ThisTestClass(BasePyfakefsTestClass):
 
     def setUp(self):
         self.setUpPyfakefs()
-        self.env_ctx = EnvContext()
+        self.env_ctx = (
+            ContextBuilder()
+            #
+            .entry_func(EntryFunc.func_boot_env)
+            #
+            .is_app(True)
+            #
+            .state_stride(StateStride.stride_py_unknown)
+            #
+            .build_context()
+        )
 
         self.fs.create_dir(mock_client_dir)
         os.chdir(mock_client_dir)

--- a/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_stride_py_venv_reached.py
+++ b/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_stride_py_venv_reached.py
@@ -23,6 +23,7 @@ from protoprimer.primer_kernel import (
     ConfConstEnv,
     ConfConstGeneral,
     ContextBuilder,
+    EntryFunc,
     EnvContext,
     EnvState,
     EnvVar,
@@ -50,7 +51,11 @@ class ThisTestClass(BasePyfakefsTestClass):
         self.env_ctx = (
             ContextBuilder()
             #
+            .entry_func(EntryFunc.func_boot_env)
+            #
             .is_app(True)
+            #
+            .state_stride(StateStride.stride_py_unknown)
             #
             .build_context()
         )

--- a/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_stride_src_updated_reached.py
+++ b/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_stride_src_updated_reached.py
@@ -11,6 +11,7 @@ from protoprimer.primer_kernel import (
     Factory_state_proto_code_file_abs_path_inited,
     Factory_state_proto_code_updated,
     ContextBuilder,
+    EntryFunc,
     EnvState,
     StateStride,
     Bootstrapper_state_local_venv_dir_abs_path_inited,
@@ -24,6 +25,10 @@ class ThisTestClass(BasePyfakefsTestClass):
         self.setUpPyfakefs()
         self.env_ctx = (
             ContextBuilder()
+            #
+            .entry_func(EntryFunc.func_boot_env)
+            #
+            .is_app(True)
             #
             .build_context()
         )

--- a/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_venv_driver_prepared.py
+++ b/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_venv_driver_prepared.py
@@ -16,6 +16,7 @@ from protoprimer.primer_kernel import (
     Bootstrapper_state_selected_python_file_abs_path_inited,
     Bootstrapper_state_venv_driver_inited,
     ContextBuilder,
+    EntryFunc,
     EnvState,
     VenvDriverPip,
     VenvDriverType,
@@ -29,6 +30,8 @@ from protoprimer.primer_kernel import (
 def env_ctx():
     return (
         ContextBuilder()
+        #
+        .entry_func(EntryFunc.func_boot_env)
         #
         .is_app(True)
         #

--- a/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_version_constraints_generated.py
+++ b/src/protoprimer/test/test_protoprimer/test_fast_slim_max_mocked/test_state_bootstrapper/test_state_version_constraints_generated.py
@@ -16,6 +16,7 @@ from protoprimer.primer_kernel import (
     Bootstrapper_state_version_constraints_file_basename_inited,
     ConfConstEnv,
     ContextBuilder,
+    EntryFunc,
     EnvContext,
     EnvState,
     Factory_state_input_sub_command_arg_loaded,
@@ -29,6 +30,8 @@ class ThisTestClass(BasePyfakefsTestClass):
         self.setUpPyfakefs()
         self.env_ctx = (
             ContextBuilder()
+            #
+            .entry_func(EntryFunc.func_boot_env)
             #
             .is_app(True)
             #
@@ -62,6 +65,8 @@ class ThisTestClass(BasePyfakefsTestClass):
         self.fs.reset()
         self.env_ctx = (
             ContextBuilder()
+            #
+            .entry_func(EntryFunc.func_boot_env)
             #
             .is_app(True)
             #
@@ -113,6 +118,8 @@ class ThisTestClass(BasePyfakefsTestClass):
         self.fs.reset()
         self.env_ctx = (
             ContextBuilder()
+            #
+            .entry_func(EntryFunc.func_boot_env)
             #
             .is_app(True)
             #


### PR DESCRIPTION
*   `None`-ify and annotate fields in `EnvContext`.
*   Make `ContextBuilder` match names and types of `EnvContext.*` fields.
*   Use local `import`-s for single users.