### PR TITLE
Remove prefixes from titles for docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,5 +1,8 @@
 # Configuration file for the Sphinx documentation builder.
 import os
+import re
+
+from docutils import nodes
 
 # TODO: This is a temporary option to have a basic `readthedocs` page while the rest of the docs are in progress.
 #       When changed here, it should also be changed in `./index.rst` (automation did not work):
@@ -158,3 +161,48 @@ html_sidebars = {
         "navigation.html",
     ],
 }
+
+# Matches tag prefixes like `FT_00_00_00_00` or `UC_00_00_00_00` at start of title.
+_TAGGED_TITLE_RE = re.compile(r"^[A-Z]+_\d+_\d+_\d+_\d+\.")
+
+
+def _strip_tag_prefix(text: str) -> str:
+    # Remove leading tag like `FT_00_00_00_00` or `UC_00_00_00_00` from a title string.
+    return _TAGGED_TITLE_RE.sub("", text)
+
+
+def _on_doctree_resolved(
+    app,
+    doctree,
+    docname,
+):
+    # Strip tag prefix from the first title node (page <h1>).
+    # Fires after `toctree` has already captured `env.titles`,
+    # so `reference.html` listings keep the full prefixed title
+    # while the individual page shows only the suffix
+    # (e.g. `some_name` instead of `FT_00_00_00_00.some_name`).
+    for node in doctree.traverse(nodes.title):
+        raw = node.astext()
+        stripped = _strip_tag_prefix(raw)
+        if stripped != raw:
+            node.clear()
+            node += nodes.Text(stripped)
+        break
+
+
+def _on_html_page_context(
+    app,
+    pagename,
+    templatename,
+    context,
+    doctree,
+):
+    # Strip tag prefix from `context["title"]`
+    # so the browser tab title matches the stripped <h1> set by `_on_doctree_resolved`.
+    if "title" in context:
+        context["title"] = _strip_tag_prefix(context["title"])
+
+
+def setup(app):
+    app.connect("doctree-resolved", _on_doctree_resolved)
+    app.connect("html-page-context", _on_html_page_context)

--- a/doc/feature_topic/FT_00_22_19_59.derived_config.md
+++ b/doc/feature_topic/FT_00_22_19_59.derived_config.md
@@ -1,6 +1,6 @@
 ---
 feature_topic: FT_00_22_19_59
-topic_title: derived config
+topic_title: derived_config
 topic_status: TODO
 ---
 
@@ -10,8 +10,8 @@ topic_status: TODO
 The derived config is for convenience to access the final values with all evaluations applied.
 
 See:
-*   [FT_23_37_64_44.global_vs_local.md][FT_23_37_64_44.global_vs_local.md] for `global` and `local` configs.
-*   [FT_89_41_35_82.conf_leap.md][FT_89_41_35_82.conf_leap.md] for config leaps.
+*   [global_vs_local][FT_23_37_64_44.global_vs_local.md] for `global` and `local` configs.
+*   [conf_leap][FT_89_41_35_82.conf_leap.md] for config leaps.
 
 Any field in `global` config can be overridden by a field in `local` config.
 To resolve the ambiguity of selecting config values, the `protoprimer` implements "derived config".
@@ -21,7 +21,7 @@ The derived config combines all the original (config files) fields and includes 
 The derived field values may have any logic to evaluate them (implemented by one of the states).
 
 While states depend on other states (states consume values of other states),
-derived config is conveniently reported via [FT_19_44_42_19.effective_config.md][FT_19_44_42_19.effective_config.md].
+derived config is conveniently reported via [effective_config][FT_19_44_42_19.effective_config.md].
 
 [FT_23_37_64_44.global_vs_local.md]: FT_23_37_64_44.global_vs_local.md
 [FT_89_41_35_82.conf_leap.md]: FT_89_41_35_82.conf_leap.md

--- a/doc/feature_topic/FT_02_89_37_65.shebang_line.md
+++ b/doc/feature_topic/FT_02_89_37_65.shebang_line.md
@@ -1,6 +1,6 @@
 ---
 feature_topic: FT_02_89_37_65
-topic_title: shebang line
+topic_title: shebang_line
 topic_status: TODO
 ---
 
@@ -11,10 +11,10 @@ TODO: TODO_91_75_37_57.implement_shebang_update.md
 
 ## Intro
 
-When [FT_75_87_82_46.entry_script.md][FT_75_87_82_46.entry_script.md] starts,
+When [entry_script][FT_75_87_82_46.entry_script.md] starts,
 it runs as [shebang line][shebang_wiki] instructs.
 
-When [FT_90_65_67_62.proto_code.md][FT_90_65_67_62.proto_code.md] is used as an entry script directly,
+When [proto_code][FT_90_65_67_62.proto_code.md] is used as an entry script directly,
 it is possible to configure shebang line when `proto_code` copy is automatically updated.
 
 ## Primary use case
@@ -26,10 +26,10 @@ change the behavior of the script:
 #!/usr/bin/env -S ENV_VAR_1=value_1 ENV_VAR_2=value_2 python
 ```
 
-It is especially useful in the case of minimal [FT_59_95_81_63.env_layout.md][FT_59_95_81_63.env_layout.md]
+It is especially useful in the case of minimal [env_layout][FT_59_95_81_63.env_layout.md]
 when the client code is kept clean of any extra config files.
 This is the only way to tell `proto_code` a non-default path to the file with `leap_primer` conf
-(see [FT_89_41_35_82.conf_leap.md][FT_89_41_35_82.conf_leap.md]).
+(see [conf_leap][FT_89_41_35_82.conf_leap.md]).
 
 However, the approach is limited by the maximum size of the shebang line (practically, it is only 127 chars).
 

--- a/doc/feature_topic/FT_05_08_64_67.start_app.md
+++ b/doc/feature_topic/FT_05_08_64_67.start_app.md
@@ -16,9 +16,9 @@ During this function, `protoprimer`:
 
 Specifically, it avoids populating the `venv` or downloading the required `python` version.
 
-The case is indicated by `EntryFunc.func_start_app` (see [FT_25_62_13_55.entry_func.md][FT_25_62_13_55.entry_func.md]).
+The case is indicated by `EntryFunc.func_start_app` (see [entry_func][FT_25_62_13_55.entry_func.md]).
 
-See also [FT_58_74_37_70.boot_vs_start.md][FT_58_74_37_70.boot_vs_start.md].
+See also [boot_vs_start][FT_58_74_37_70.boot_vs_start.md].
 
 [FT_25_62_13_55.entry_func.md]: FT_25_62_13_55.entry_func.md
 [FT_58_74_37_70.boot_vs_start.md]: FT_58_74_37_70.boot_vs_start.md

--- a/doc/feature_topic/FT_07_55_61_77.exit_point.md
+++ b/doc/feature_topic/FT_07_55_61_77.exit_point.md
@@ -13,17 +13,17 @@ An `exit_point` is the place where `protoprimer` transfers control to custom ste
 
 There are several `exit_point`-s:
 
-*   Leaving `protoprimer` DAG part and entering custom DAG part via [FT_85_17_35_21.boot_env.md][FT_85_17_35_21.boot_env.md].
+*   Leaving `protoprimer` DAG part and entering custom DAG part via [boot_env][FT_85_17_35_21.boot_env.md].
 
-*   Starting `some_main` function or module via [FT_05_08_64_67.start_app.md][FT_05_08_64_67.start_app.md].
+*   Starting `some_main` function or module via [start_app][FT_05_08_64_67.start_app.md].
 
-*   Finishing execution of `lib` function - see [FT_93_57_03_75.app_vs_lib.md][FT_93_57_03_75.app_vs_lib.md].
+*   Finishing execution of `lib` function - see [app_vs_lib][FT_93_57_03_75.app_vs_lib.md].
 
-*   Invoking `shell` via [FT_99_89_51_06.venv_shell.md][FT_99_89_51_06.venv_shell.md].
+*   Invoking `shell` via [venv_shell][FT_99_89_51_06.venv_shell.md].
 
 ## Context isolation
 
-See [FT_66_02_54_56.context_isolation.md][FT_66_02_54_56.context_isolation.md].
+See [context_isolation][FT_66_02_54_56.context_isolation.md].
 
 [FT_85_17_35_21.boot_env.md]: FT_85_17_35_21.boot_env.md
 [FT_05_08_64_67.start_app.md]: FT_05_08_64_67.start_app.md

--- a/doc/feature_topic/FT_08_92_69_92.env_var.md
+++ b/doc/feature_topic/FT_08_92_69_92.env_var.md
@@ -1,6 +1,6 @@
 ---
 feature_topic: FT_08_92_69_92
-topic_title: env var
+topic_title: env_var
 topic_status: TODO
 ---
 
@@ -10,7 +10,7 @@ topic_status: TODO
 With no args (convenience requirement of a bootstrap script),
 the only way to override defaults before it reaches config files is to use env vars.
 
-They can also be configured in [FT_02_89_37_65.shebang_line.md][FT_02_89_37_65.shebang_line.md].
+They can also be configured in [shebang_line][FT_02_89_37_65.shebang_line.md].
 
 ## Supported env vars
 
@@ -26,7 +26,7 @@ See `EnvVar` enum inside `protoprimer.primer_kernel`.
 
 ## Context isolation
 
-See [FT_66_02_54_56.context_isolation.md][FT_66_02_54_56.context_isolation.md].
+See [context_isolation][FT_66_02_54_56.context_isolation.md].
 
 [FT_02_89_37_65.shebang_line.md]: FT_02_89_37_65.shebang_line.md
 [FT_66_02_54_56.context_isolation.md]: FT_66_02_54_56.context_isolation.md

--- a/doc/feature_topic/FT_11_27_29_83.sub_command.md
+++ b/doc/feature_topic/FT_11_27_29_83.sub_command.md
@@ -1,6 +1,6 @@
 ---
 feature_topic: FT_11_27_29_83
-topic_title: sub command
+topic_title: sub_command
 topic_status: TODO
 ---
 
@@ -9,9 +9,9 @@ topic_status: TODO
 
 ## Intro
 
-Sub command refers to what [FT_90_65_67_62.proto_code.md][FT_90_65_67_62.proto_code.md] is invoked for.
+Sub command refers to what [proto_code][FT_90_65_67_62.proto_code.md] is invoked for.
 
-It changes how the script traverses the [FT_68_54_41_96.state_dependency.md][FT_68_54_41_96.state_dependency.md]
+It changes how the script traverses the [state_dependency][FT_68_54_41_96.state_dependency.md]
 and affects how each state is bootstrapped.
 
 Sub commands are supposed to be selected via CLI:
@@ -22,7 +22,7 @@ Sub commands are supposed to be selected via CLI:
 
 ## See also
 
-*   [FT_25_62_13_55.entry_func.md][FT_25_62_13_55.entry_func.md]
+*   [entry_func][FT_25_62_13_55.entry_func.md]
 
 [FT_90_65_67_62.proto_code.md]: FT_90_65_67_62.proto_code.md
 [FT_68_54_41_96.state_dependency.md]: FT_68_54_41_96.state_dependency.md

--- a/doc/feature_topic/FT_13_56_86_20.troubleshooting.md
+++ b/doc/feature_topic/FT_13_56_86_20.troubleshooting.md
@@ -9,6 +9,6 @@ topic_status: TODO
 
 TODO: Add a section on troubleshooting: `boot_env`, `start_app`, `lib`, etc.
 
-See [FT_38_73_38_52.log_verbosity.md][FT_38_73_38_52.log_verbosity.md].
+See [log_verbosity][FT_38_73_38_52.log_verbosity.md].
 
 [FT_38_73_38_52.log_verbosity.md]: FT_38_73_38_52.log_verbosity.md

--- a/doc/feature_topic/FT_14_52_73_23.primer_runtime.md
+++ b/doc/feature_topic/FT_14_52_73_23.primer_runtime.md
@@ -1,6 +1,6 @@
 ---
 feature_topic: FT_14_52_73_23
-topic_title: primer runtime
+topic_title: primer_runtime
 topic_status: TODO
 ---
 
@@ -10,8 +10,8 @@ topic_status: TODO
 ## `protoprimer` execution runtimes
 
 TODO: It seems like this concept of runtimes is redundant:
-    -   [FT_72_45_12_06.python_executable.md][FT_72_45_12_06.python_executable.md] cover python exec transition
-    -   [FT_89_41_35_82.conf_leap.md][FT_89_41_35_82.conf_leap.md] covers configuration discovery
+    -   [python_executable][FT_72_45_12_06.python_executable.md] cover python exec transition
+    -   [conf_leap][FT_89_41_35_82.conf_leap.md] covers configuration discovery
     What does runtime explain?
     Whether control is transferred outside of implementation done by `protoprimer`.
     When does the transition from one runtime to another change?
@@ -21,7 +21,7 @@ There are a few primer runtimes:
 
 *   `proto` = independent (stand-alone)
 
-    This runtime runs [FT_90_65_67_62.proto_code.md][FT_90_65_67_62.proto_code.md].
+    This runtime runs [proto_code][FT_90_65_67_62.proto_code.md].
 
     It is designed to start outside of `venv` (or inside arbitrary `venv` without `protoprimer` package installed).
 
@@ -43,28 +43,28 @@ There are a few primer runtimes:
 ## Why do we need these runtimes?
 
 The `proto` runtime must not import other non-standard packages (which are accessed via `venv` later) when it starts -
-it runs a stand-alone [FT_90_65_67_62.proto_code.md][FT_90_65_67_62.proto_code.md]
+it runs a stand-alone [proto_code][FT_90_65_67_62.proto_code.md]
 (limited only to the states defined there).
 
 Any client-specific states only become accessible in `meta` runtime which starts
-another [FT_72_45_12_06.python_executable.md][FT_72_45_12_06.python_executable.md].
+another [python_executable][FT_72_45_12_06.python_executable.md].
 
 ## How does transition from `proto` to `meta` runtimes work?
 
-It relies on a helper function from [FT_90_65_67_62.proto_code.md][FT_90_65_67_62.proto_code.md]
-used by the [FT_75_87_82_46.entry_script.md][FT_75_87_82_46.entry_script.md] -
-see [FT_58_74_37_70.boot_vs_start.md][FT_58_74_37_70.boot_vs_start.md].
+It relies on a helper function from [proto_code][FT_90_65_67_62.proto_code.md]
+used by the [entry_script][FT_75_87_82_46.entry_script.md] -
+see [boot_vs_start][FT_58_74_37_70.boot_vs_start.md].
 
-Depending on whether it is `venv` or not (see [FT_14_52_73_23.primer_runtime.md][FT_14_52_73_23.primer_runtime.md]),
+Depending on whether it is `venv` or not (see [primer_runtime][FT_14_52_73_23.primer_runtime.md]),
 the helper function passes control to different `selected_main`:
 *   Outside `venv` (without necessary packages), it executes `selected_main` from `proto_kernel`.
 *   Inside `venv` (with necessary packages), it executes `selected_main` from `client_code`.
 
-It also requires [FT_62_88_55_10.CLI_compatibility.md][FT_62_88_55_10.CLI_compatibility.md].
+It also requires [CLI_compatibility][FT_62_88_55_10.CLI_compatibility.md].
 
 ## How to specify target state available only in `meta` runtime?
 
-See [FT_74_10_40_33.DAG_extension.md][FT_74_10_40_33.DAG_extension.md].
+See [DAG_extension][FT_74_10_40_33.DAG_extension.md].
 
 [FT_90_65_67_62.proto_code.md]: FT_90_65_67_62.proto_code.md
 [FT_72_45_12_06.python_executable.md]: FT_72_45_12_06.python_executable.md

--- a/doc/feature_topic/FT_17_41_51_83.private_artifact_repo.md
+++ b/doc/feature_topic/FT_17_41_51_83.private_artifact_repo.md
@@ -1,6 +1,6 @@
 ---
 feature_topic: FT_17_41_51_83
-topic_title: private artifact repo
+topic_title: private_artifact_repo
 topic_status: TODO
 ---
 

--- a/doc/feature_topic/FT_19_44_42_19.effective_config.md
+++ b/doc/feature_topic/FT_19_44_42_19.effective_config.md
@@ -1,6 +1,6 @@
 ---
 feature_topic: FT_19_44_42_19
-topic_title: effective config
+topic_title: effective_config
 topic_status: TODO
 ---
 
@@ -22,8 +22,8 @@ It is possible to evaluate the effective config to see:
 
 TODO: update this - no more `python` format (unless `./cmd/eval_conf`):
 The effective config uses `python` format (to render comments):
-*   for all loaded files in JSON (see [FT_48_62_07_98.config_format.md][FT_48_62_07_98.config_format.md])
-*   and also for [FT_00_22_19_59.derived_config.md][FT_00_22_19_59.derived_config.md]
+*   for all loaded files in JSON (see [config_format][FT_48_62_07_98.config_format.md])
+*   and also for [derived_config][FT_00_22_19_59.derived_config.md]
 
 This obsoleted interactive wizard mode that was:
 *   less convenient: the user has to navigate via CLI dialogue

--- a/doc/feature_topic/FT_21_75_54_18.instant_scenario.md
+++ b/doc/feature_topic/FT_21_75_54_18.instant_scenario.md
@@ -1,13 +1,13 @@
 ---
 feature_topic: FT_21_75_54_18
-topic_title: instant scenario
+topic_title: instant_scenario
 topic_status: TEST
 ---
 
 # FT_21_75_54_18.instant_scenario
 
 Instant scenario is the way to start using protoprimer -
-simply by adding [FT_87_17_49_36.kernel_copy.md][FT_87_17_49_36.kernel_copy.md]
+simply by adding [kernel_copy][FT_87_17_49_36.kernel_copy.md]
 to the target repo (without configuring anything).
 
 [FT_87_17_49_36.kernel_copy.md]: FT_87_17_49_36.kernel_copy.md

--- a/doc/feature_topic/FT_22_11_94_65.bootstrap_precondition.md
+++ b/doc/feature_topic/FT_22_11_94_65.bootstrap_precondition.md
@@ -1,13 +1,13 @@
 ---
 feature_topic: FT_22_11_94_65
-topic_title: bootstrap preconditions
+topic_title: bootstrap_precondition
 topic_status: TODO
 ---
 
 
 # FT_22_11_94_65.bootstrap_precondition
 
-These are preconditions to run [FT_90_65_67_62.proto_code.md][FT_90_65_67_62.proto_code.md]:
+These are preconditions to run [proto_code][FT_90_65_67_62.proto_code.md]:
 
 *   `python3` in `PATH` environment variable of the shell:
 
@@ -19,11 +19,11 @@ These are preconditions to run [FT_90_65_67_62.proto_code.md][FT_90_65_67_62.pro
     /usr/bin/python3
     ```
 
-    The exact name of the interpreter depends on [FT_02_89_37_65.shebang_line.md][FT_02_89_37_65.shebang_line.md].
+    The exact name of the interpreter depends on [shebang_line][FT_02_89_37_65.shebang_line.md].
 
 *   `python` version
 
-    See [FT_84_11_73_28.supported_python_versions.md][FT_84_11_73_28.supported_python_versions.md].
+    See [supported_python_versions][FT_84_11_73_28.supported_python_versions.md].
 
 [FT_90_65_67_62.proto_code.md]: FT_90_65_67_62.proto_code.md
 [FT_02_89_37_65.shebang_line.md]: FT_02_89_37_65.shebang_line.md

--- a/doc/feature_topic/FT_23_37_64_44.global_vs_local.md
+++ b/doc/feature_topic/FT_23_37_64_44.global_vs_local.md
@@ -48,7 +48,7 @@ but all its possible targets in `dst/*` have to be versioned.
 ## Relation to config layout
 
 In the context of `protoprimer`,
-there are two distinct configurations closely related to [FT_89_41_35_82.conf_leap.md][FT_89_41_35_82.conf_leap.md]:
+there are two distinct configurations closely related to [conf_leap][FT_89_41_35_82.conf_leap.md]:
 
 *   `source_global` configuration is stored in a config file common to all deployment (related to `leap_client`).
 
@@ -65,7 +65,7 @@ There are simple/limited and complex/flexible approaches to "merging" the two da
 The 1st approach is used for the common fields
 where values from `source_local` take precedence over values from `source_global`.
 
-The 2nd approach is used by [FT_00_22_19_59.derived_config.md][FT_00_22_19_59.derived_config.md].
+The 2nd approach is used by [derived_config][FT_00_22_19_59.derived_config.md].
 
 [FT_02_89_37_65.shebang_line.md]: FT_02_89_37_65.shebang_line.md
 [FT_89_41_35_82.conf_leap.md]: FT_89_41_35_82.conf_leap.md

--- a/doc/feature_topic/FT_25_62_13_55.entry_func.md
+++ b/doc/feature_topic/FT_25_62_13_55.entry_func.md
@@ -12,14 +12,14 @@ topic_status: TODO
 Enum `EntryFunc` specifies what was the entry point to `proto_kernel`.
 
 Depending on the `EntryFunc`, the shape of the DAG changes.
-See [FT_77_15_06_50.dynamic_DAG.md][FT_77_15_06_50.dynamic_DAG.md].
+See [dynamic_DAG][FT_77_15_06_50.dynamic_DAG.md].
 
 ## See also
 
-*   [FT_58_74_37_70.boot_vs_start.md][FT_58_74_37_70.boot_vs_start.md]
-*   [FT_11_27_29_83.sub_command.md][FT_11_27_29_83.sub_command.md]
-*   [FT_93_57_03_75.app_vs_lib.md][FT_93_57_03_75.app_vs_lib.md]
-*   [FT_62_88_55_10.CLI_compatibility.md][FT_62_88_55_10.CLI_compatibility.md]
+*   [boot_vs_start][FT_58_74_37_70.boot_vs_start.md]
+*   [sub_command][FT_11_27_29_83.sub_command.md]
+*   [app_vs_lib][FT_93_57_03_75.app_vs_lib.md]
+*   [CLI_compatibility][FT_62_88_55_10.CLI_compatibility.md]
 
 [FT_93_57_03_75.app_vs_lib.md]: FT_93_57_03_75.app_vs_lib.md
 [FT_62_88_55_10.CLI_compatibility.md]: FT_62_88_55_10.CLI_compatibility.md

--- a/doc/feature_topic/FT_28_25_63_06.isolated_python.md
+++ b/doc/feature_topic/FT_28_25_63_06.isolated_python.md
@@ -1,6 +1,6 @@
 ---
 feature_topic: FT_28_25_63_06
-topic_title: isolated python
+topic_title: isolated_python
 topic_status: TODO
 ---
 
@@ -14,10 +14,10 @@ When `python` imports non-standard module, it must import it from the dedicated 
 The `protoprimer` is designed to work in isolated environment sharing no non-standard packages.
 This allows multiple independent deployments on the same host for the same user.
 
-It covers both `app` & `lib` cases (see [FT_93_57_03_75.app_vs_lib.md][FT_93_57_03_75.app_vs_lib.md]) -
+It covers both `app` & `lib` cases (see [app_vs_lib][FT_93_57_03_75.app_vs_lib.md]) -
 any import of non-standard `python` packages must be guaranteed to be from dedicated `venv`.
 
-The only exception to this rule is `proto_code` (see [FT_90_65_67_62.proto_code.md][FT_90_65_67_62.proto_code.md]) -
+The only exception to this rule is `proto_code` (see [proto_code][FT_90_65_67_62.proto_code.md]) -
 see `CASE_3` below.
 
 ## Approach
@@ -33,7 +33,7 @@ The `entry_script` imports `proto_code` module (file) via that relative path.
 
 Then, it initiates `python` switch sequence.
 
-See also [UC_54_26_66_63.lib_access_to_config_data.md][UC_54_26_66_63.lib_access_to_config_data.md].
+See also [lib_access_to_config_data][UC_54_26_66_63.lib_access_to_config_data.md].
 
 ### `CASE_2`: `app` starting from `entry_script`
 
@@ -58,19 +58,19 @@ TODO: add mermaid diagram with transitions of `python` processes.
 ## Related articles
 
 `feature_topic`-s:
-*   [FT_02_89_37_65.shebang_line.md][FT_02_89_37_65.shebang_line.md]
-*   [FT_14_52_73_23.primer_runtime.md][FT_14_52_73_23.primer_runtime.md]
-*   [FT_22_11_94_65.bootstrap_precondition.md][FT_22_11_94_65.bootstrap_precondition.md]
-*   [FT_44_72_60_67.python_vs_shell.md][FT_44_72_60_67.python_vs_shell.md]
-*   [FT_46_37_27_11.editable_install.md][FT_46_37_27_11.editable_install.md]
-*   [FT_57_87_94_94.bootstrap_process.md][FT_57_87_94_94.bootstrap_process.md]
-*   [FT_62_88_55_10.CLI_compatibility.md][FT_62_88_55_10.CLI_compatibility.md]
-*   [FT_72_45_12_06.python_executable.md][FT_72_45_12_06.python_executable.md]
-*   [FT_75_87_82_46.entry_script.md][FT_75_87_82_46.entry_script.md]
-*   [FT_90_65_67_62.proto_code.md][FT_90_65_67_62.proto_code.md]
+*   [shebang_line][FT_02_89_37_65.shebang_line.md]
+*   [primer_runtime][FT_14_52_73_23.primer_runtime.md]
+*   [bootstrap_precondition][FT_22_11_94_65.bootstrap_precondition.md]
+*   [python_vs_shell][FT_44_72_60_67.python_vs_shell.md]
+*   [editable_install][FT_46_37_27_11.editable_install.md]
+*   [bootstrap_process][FT_57_87_94_94.bootstrap_process.md]
+*   [CLI_compatibility][FT_62_88_55_10.CLI_compatibility.md]
+*   [python_executable][FT_72_45_12_06.python_executable.md]
+*   [entry_script][FT_75_87_82_46.entry_script.md]
+*   [proto_code][FT_90_65_67_62.proto_code.md]
 
 `use_case`-s:
-*   [UC_90_98_17_93.run_under_venv.md][UC_90_98_17_93.run_under_venv.md]
+*   [run_under_venv][UC_90_98_17_93.run_under_venv.md]
 
 [FT_02_89_37_65.shebang_line.md]: FT_02_89_37_65.shebang_line.md
 [FT_14_52_73_23.primer_runtime.md]: FT_14_52_73_23.primer_runtime.md

--- a/doc/feature_topic/FT_30_24_95_65.state_idempotency.md
+++ b/doc/feature_topic/FT_30_24_95_65.state_idempotency.md
@@ -1,6 +1,6 @@
 ---
 feature_topic: FT_30_24_95_65
-topic_title: state idempotency
+topic_title: state_idempotency
 topic_status: TODO
 ---
 
@@ -12,9 +12,9 @@ Each state value is treated as idempotent (re-evaluation/re-bootstrapping of sta
 Because of that (for optimization), the evaluated value may be cached.
 Caching ensures idempotency "de facto" (at least, within current `python` process),
 nevertheless, it must be followed "de jure" because `proto_code` re-starts itself using
-different [FT_72_45_12_06.python_executable.md][FT_72_45_12_06.python_executable.md].
+different [python_executable][FT_72_45_12_06.python_executable.md].
 
-If the state has to have different values evaluated for different moments within [FT_57_87_94_94.bootstrap_process.md][FT_57_87_94_94.bootstrap_process.md],
+If the state has to have different values evaluated for different moments within [bootstrap_process][FT_57_87_94_94.bootstrap_process.md],
 this has to be two different states (different names) and implemented accordingly.
 
 [FT_72_45_12_06.python_executable.md]: FT_72_45_12_06.python_executable.md

--- a/doc/feature_topic/FT_32_61_30_43.monorepo_support.md
+++ b/doc/feature_topic/FT_32_61_30_43.monorepo_support.md
@@ -1,6 +1,6 @@
 ---
 feature_topic: FT_32_61_30_43
-topic_title: monorepo support
+topic_title: monorepo_support
 topic_status: TODO
 ---
 

--- a/doc/feature_topic/FT_34_97_51_30.optional_module.md
+++ b/doc/feature_topic/FT_34_97_51_30.optional_module.md
@@ -1,6 +1,6 @@
 ---
 feature_topic: FT_34_97_51_30
-topic_title: optional module
+topic_title: optional_module
 topic_status: TODO
 ---
 
@@ -13,14 +13,14 @@ multiple modules which `primer_kernel` imports (when in `runtime_meta`).
 
 ## Intro
 
-Some functionality from `proto_code` [FT_90_65_67_62.proto_code.md][FT_90_65_67_62.proto_code.md] may be optional.
+Some functionality from `proto_code` [proto_code][FT_90_65_67_62.proto_code.md] may be optional.
 
 Optional functionality is provided via optional modules
 which are maintained the same way as the main `protoprimer.primer_kernel` module:
 *   during `runtime_proto`, import goes from a copy
 *   during `runtime_meta`, import goes from the deployed package
 
-For example, `eval` sub command (see [FT_19_44_42_19.effective_config.md][FT_19_44_42_19.effective_config.md])
+For example, `eval` sub command (see [effective_config][FT_19_44_42_19.effective_config.md])
 is implemented via:
 *   `proto_config.py` module during `runtime_proto`
 *   `protoprimer.primer_config` module during `runtime_meta`
@@ -32,7 +32,7 @@ either expose or not certain options to user.
 
 ## Minimal layout
 
-In the case of min layout (see [FT_59_95_81_63.env_layout.md][FT_59_95_81_63.env_layout.md]),
+In the case of min layout (see [env_layout][FT_59_95_81_63.env_layout.md]),
 it should be optional to deploy a copy of optional modules together with the copy of `primer_kernel`.
 
 ## Approach to `import`

--- a/doc/feature_topic/FT_38_73_38_52.log_verbosity.md
+++ b/doc/feature_topic/FT_38_73_38_52.log_verbosity.md
@@ -1,6 +1,6 @@
 ---
 feature_topic: FT_38_73_38_52
-topic_title: log verbosity
+topic_title: log_verbosity
 topic_status: TODO
 ---
 

--- a/doc/feature_topic/FT_42_03_79_73.reboot_env.md
+++ b/doc/feature_topic/FT_42_03_79_73.reboot_env.md
@@ -46,7 +46,7 @@ To re-create the `venv`, re-install the deps, and re-pin the versions, run:
 
 ## Implementation
 
-*   Remove [FT_92_51_35_07.local_env_link.md][FT_92_51_35_07.local_env_link.md] to re-select the env.
+*   Remove [local_env_link][FT_92_51_35_07.local_env_link.md] to re-select the env.
 
     TODO: TODO_41_10_50_01.implement_env_selector.md: implement automatic env selection.
 
@@ -58,9 +58,9 @@ To re-create the `venv`, re-install the deps, and re-pin the versions, run:
 
 *   Remove `constraints.txt` to re-compute dependency versions (only via spec in `pyproject.toml`).
 
-This feature also addresses [UC_61_12_90_59.upgrade_venv.md][UC_61_12_90_59.upgrade_venv.md].
+This feature also addresses [upgrade_venv][UC_61_12_90_59.upgrade_venv.md].
 
-See also [UC_44_82_07_30.requirements_lock.md][UC_44_82_07_30.requirements_lock.md].
+See also [requirements_lock][UC_44_82_07_30.requirements_lock.md].
 
 [UC_44_82_07_30.requirements_lock.md]: ../use_case/UC_44_82_07_30.requirements_lock.md
 [FT_92_51_35_07.local_env_link.md]: FT_92_51_35_07.local_env_link.md

--- a/doc/feature_topic/FT_44_72_60_67.python_vs_shell.md
+++ b/doc/feature_topic/FT_44_72_60_67.python_vs_shell.md
@@ -1,6 +1,6 @@
 ---
 feature_topic: FT_44_72_60_67
-topic_title: python vs shell
+topic_title: python_vs_shell
 topic_status: TODO
 ---
 

--- a/doc/feature_topic/FT_46_37_27_11.editable_install.md
+++ b/doc/feature_topic/FT_46_37_27_11.editable_install.md
@@ -1,6 +1,6 @@
 ---
 feature_topic: FT_46_37_27_11
-topic_title: editable install
+topic_title: editable_install
 topic_status: TODO
 ---
 

--- a/doc/feature_topic/FT_48_62_07_98.config_format.md
+++ b/doc/feature_topic/FT_48_62_07_98.config_format.md
@@ -1,6 +1,6 @@
 ---
 feature_topic: FT_48_62_07_98
-topic_title: config format
+topic_title: config_format
 topic_status: TODO
 ---
 
@@ -16,7 +16,7 @@ This leaves only JSON (even though it does not support comments).
 Nevertheless, `protoprimer` does not need very complex config data, therefore, using JSON is practical enough.
 
 At the same time, each field is described using annotated
-[FT_19_44_42_19.effective_config.md][FT_19_44_42_19.effective_config.md] which renderers JSON in `python` format
+[effective_config][FT_19_44_42_19.effective_config.md] which renderers JSON in `python` format
 (allowing comments).
 
 [FT_19_44_42_19.effective_config.md]: FT_19_44_42_19.effective_config.md

--- a/doc/feature_topic/FT_55_04_06_82.test_code_style.md
+++ b/doc/feature_topic/FT_55_04_06_82.test_code_style.md
@@ -8,7 +8,7 @@ topic_status: TEST
 
 ## test code extends prod code style
 
-Apply rules from [FT_43_27_70_50.prod_code_style.md][FT_43_27_70_50.prod_code_style.md].
+Apply rules from [prod_code_style][FT_43_27_70_50.prod_code_style.md].
 
 ## given when then
 

--- a/doc/feature_topic/FT_57_87_94_94.bootstrap_process.md
+++ b/doc/feature_topic/FT_57_87_94_94.bootstrap_process.md
@@ -1,6 +1,6 @@
 ---
 feature_topic: FT_57_87_94_94
-topic_title: bootstrap process
+topic_title: bootstrap_process
 topic_status: TODO
 ---
 
@@ -24,16 +24,16 @@ which:
 ## Details
 
 The entire bootstrap process involves multiple steps, concepts, "dimensions":
-*   [FT_22_11_94_65.bootstrap_precondition.md][FT_22_11_94_65.bootstrap_precondition.md] to be met before the start
-*   [FT_75_87_82_46.entry_script.md][FT_75_87_82_46.entry_script.md] executed by the user
-*   [FT_02_89_37_65.shebang_line.md][FT_02_89_37_65.shebang_line.md] which selects env vars and `python` interpreter
-*   [FT_11_27_29_83.sub_command.md][FT_11_27_29_83.sub_command.md] where bootstrapping environment is only one of the options
-*   [FT_90_65_67_62.proto_code.md][FT_90_65_67_62.proto_code.md] implementing most of the functionality without `venv`
-*   [FT_72_45_12_06.python_executable.md][FT_72_45_12_06.python_executable.md] chain leading to required `python` version
-*   [FT_68_54_41_96.state_dependency.md][FT_68_54_41_96.state_dependency.md] graph and its traversal
-*   [FT_89_41_35_82.conf_leap.md][FT_89_41_35_82.conf_leap.md] where each configuration value is being resolved
-*   [FT_14_52_73_23.primer_runtime.md][FT_14_52_73_23.primer_runtime.md] switches from `proto` to `venv`
-*   [FT_59_95_81_63.env_layout.md][FT_59_95_81_63.env_layout.md] bootstrapped eventually
+*   [bootstrap_precondition][FT_22_11_94_65.bootstrap_precondition.md] to be met before the start
+*   [entry_script][FT_75_87_82_46.entry_script.md] executed by the user
+*   [shebang_line][FT_02_89_37_65.shebang_line.md] which selects env vars and `python` interpreter
+*   [sub_command][FT_11_27_29_83.sub_command.md] where bootstrapping environment is only one of the options
+*   [proto_code][FT_90_65_67_62.proto_code.md] implementing most of the functionality without `venv`
+*   [python_executable][FT_72_45_12_06.python_executable.md] chain leading to required `python` version
+*   [state_dependency][FT_68_54_41_96.state_dependency.md] graph and its traversal
+*   [conf_leap][FT_89_41_35_82.conf_leap.md] where each configuration value is being resolved
+*   [primer_runtime][FT_14_52_73_23.primer_runtime.md] switches from `proto` to `venv`
+*   [env_layout][FT_59_95_81_63.env_layout.md] bootstrapped eventually
 
 [DAG_wiki]: https://en.wikipedia.org/wiki/Directed_acyclic_graph
 

--- a/doc/feature_topic/FT_58_74_37_70.boot_vs_start.md
+++ b/doc/feature_topic/FT_58_74_37_70.boot_vs_start.md
@@ -11,25 +11,25 @@ topic_status: TODO
 
 There are two distinct use cases of the `protoprimer`:
 
-*   bootstrap an environment: [FT_85_17_35_21.boot_env.md][FT_85_17_35_21.boot_env.md]
+*   bootstrap an environment: [boot_env][FT_85_17_35_21.boot_env.md]
 
     Prepare `venv` and pass control to custom client bootstrap steps.
 
-    The case is indicated by `EntryFunc.func_boot_env` (see [FT_25_62_13_55.entry_func.md][FT_25_62_13_55.entry_func.md]).
+    The case is indicated by `EntryFunc.func_boot_env` (see [entry_func][FT_25_62_13_55.entry_func.md]).
 
-*   start an application: [FT_05_08_64_67.start_app.md][FT_05_08_64_67.start_app.md]
+*   start an application: [start_app][FT_05_08_64_67.start_app.md]
 
     Assume `venv` is prepared, switch to required `python` and start custom client main function.
 
-    The case is indicated by `EntryFunc.func_start_app` (see [FT_25_62_13_55.entry_func.md][FT_25_62_13_55.entry_func.md]).
+    The case is indicated by `EntryFunc.func_start_app` (see [entry_func][FT_25_62_13_55.entry_func.md]).
 
 In both cases, in order to import anything, the `protoprimer` transition itself into
-[FT_28_25_63_06.isolated_python.md][FT_28_25_63_06.isolated_python.md] inside required `venv`.
+[isolated_python][FT_28_25_63_06.isolated_python.md] inside required `venv`.
 
 TODO: TODO_03_22_24_33.consolidate_sub_command_and_entry_func_docs.md:
-These use cases partially obsolete [FT_93_57_03_75.app_vs_lib.md][FT_93_57_03_75.app_vs_lib.md]
-because there seem to be no way [FT_90_65_67_62.proto_code.md][FT_90_65_67_62.proto_code.md] can be
-considerably useful during `proto` [FT_14_52_73_23.primer_runtime.md][FT_14_52_73_23.primer_runtime.md] -
+These use cases partially obsolete [app_vs_lib][FT_93_57_03_75.app_vs_lib.md]
+because there seem to be no way [proto_code][FT_90_65_67_62.proto_code.md] can be
+considerably useful during `proto` [primer_runtime][FT_14_52_73_23.primer_runtime.md] -
 nothing for `lib` except launching an `app` as env bootstrapper or app starter.
 The `lib` functionality may still be useful but during `meta` primer runtime.
 
@@ -42,7 +42,7 @@ manifests itself in the help output that script provides (what set of args its `
 path/to/script -h
 ```
 
-The reason for that is required [FT_62_88_55_10.CLI_compatibility.md][FT_62_88_55_10.CLI_compatibility.md].
+The reason for that is required [CLI_compatibility][FT_62_88_55_10.CLI_compatibility.md].
 
 ## How to extend and customize it?
 
@@ -50,7 +50,7 @@ TODO: Explain examples `./cmd/boot_env` and `./cmd/start_app`
 
 ## See also
 
-*   [FT_25_62_13_55.entry_func.md][FT_25_62_13_55.entry_func.md]
+*   [entry_func][FT_25_62_13_55.entry_func.md]
 
 [FT_05_08_64_67.start_app.md]: FT_05_08_64_67.start_app.md
 [FT_85_17_35_21.boot_env.md]: FT_85_17_35_21.boot_env.md

--- a/doc/feature_topic/FT_59_95_81_63.env_layout.md
+++ b/doc/feature_topic/FT_59_95_81_63.env_layout.md
@@ -7,7 +7,7 @@ topic_status: TODO
 
 # FT_59_95_81_63.env_layout
 
-The layouts below are configured via [FT_89_41_35_82.conf_leap.md][FT_89_41_35_82.conf_leap.md].
+The layouts below are configured via [conf_leap][FT_89_41_35_82.conf_leap.md].
 
 ## min dir layout
 

--- a/doc/feature_topic/FT_62_88_55_10.CLI_compatibility.md
+++ b/doc/feature_topic/FT_62_88_55_10.CLI_compatibility.md
@@ -1,33 +1,33 @@
 ---
 feature_topic: FT_62_88_55_10
-topic_title: CLI compatibility
+topic_title: CLI_compatibility
 topic_status: TODO
 ---
 
 
 # FT_62_88_55_10.CLI_compatibility
 
-This doc applies to the case when `protoprimer` is used as bootstrap app - see [FT_93_57_03_75.app_vs_lib.md][FT_93_57_03_75.app_vs_lib.md].
+This doc applies to the case when `protoprimer` is used as bootstrap app - see [app_vs_lib][FT_93_57_03_75.app_vs_lib.md].
 
 ## CLI compatibility for bootstrap app
 
-Bootstrap process requires CLI compatibility to transition to `meta` runtime [FT_14_52_73_23.primer_runtime.md][FT_14_52_73_23.primer_runtime.md].
+Bootstrap process requires CLI compatibility to transition to `meta` runtime [primer_runtime][FT_14_52_73_23.primer_runtime.md].
 
-When [FT_75_87_82_46.entry_script.md][FT_75_87_82_46.entry_script.md] switches between
-[FT_14_52_73_23.primer_runtime.md][FT_14_52_73_23.primer_runtime.md],
+When [entry_script][FT_75_87_82_46.entry_script.md] switches between
+[primer_runtime][FT_14_52_73_23.primer_runtime.md],
 it must implement the same command line interface (CLI) (to handle the same set of args)
-if it uses `boot_env` function (see [FT_85_17_35_21.boot_env.md][FT_85_17_35_21.boot_env.md]).
+if it uses `boot_env` function (see [boot_env][FT_85_17_35_21.boot_env.md]).
 Otherwise, they will behave differently.
 
 From the user point of view (as exposed via CLI), the script will appear identical in both cases.
 
 It is normally achieved by calling `parse_args` from `protoprimer.primer_kernel`.
 
-This requirement does not apply to `start_app` function (see [FT_05_08_64_67.start_app.md][FT_05_08_64_67.start_app.md]).
+This requirement does not apply to `start_app` function (see [start_app][FT_05_08_64_67.start_app.md]).
 
 ## See also
 
-*   [FT_25_62_13_55.entry_func.md][FT_25_62_13_55.entry_func.md]
+*   [entry_func][FT_25_62_13_55.entry_func.md]
 
 [FT_85_17_35_21.boot_env.md]: FT_85_17_35_21.boot_env.md
 [FT_05_08_64_67.start_app.md]: FT_05_08_64_67.start_app.md

--- a/doc/feature_topic/FT_63_61_24_94.protoprimer_dictionary.md
+++ b/doc/feature_topic/FT_63_61_24_94.protoprimer_dictionary.md
@@ -1,6 +1,6 @@
 ---
 feature_topic: FT_63_61_24_94
-topic_title: protoprimer dictionary
+topic_title: protoprimer_dictionary
 topic_status: TODO
 ---
 
@@ -15,7 +15,7 @@ This doc defines terms used in the vocabulary of [protoprimer][protoprimer_link]
 
 ## "entry script"
 
-See [FT_75_87_82_46.entry_script.md][FT_75_87_82_46.entry_script.md].
+See [entry_script][FT_75_87_82_46.entry_script.md].
 
 ---
 
@@ -45,7 +45,7 @@ see [more info][google_python_main_function].
 TODO: (add an option to rename)
 It is normally named as `proto_kernel.py` to disambiguate from `protoprimer.primer_kernel`.
 
-See [FT_90_65_67_62.proto_code.md][FT_90_65_67_62.proto_code.md].
+See [proto_code][FT_90_65_67_62.proto_code.md].
 
 ---
 
@@ -58,7 +58,7 @@ The directory inside client code that is used as the base to specify most of the
 For many projects, it is natural to suggest that ref root = repo root.
 However, it may not always be the case (hence, the different name):
 *   some repo may use a nested dir as the ref root
-*   in the case of [UC_94_67_42_40.support_monorepo.md][UC_94_67_42_40.support_monorepo.md], there can be more than one ref root
+*   in the case of [support_monorepo][UC_94_67_42_40.support_monorepo.md], there can be more than one ref root
 
 The ref root is the central concept of the `protoprimer` project where every file is
 supposed to assume its own path relative to it.

--- a/doc/feature_topic/FT_66_02_54_56.context_isolation.md
+++ b/doc/feature_topic/FT_66_02_54_56.context_isolation.md
@@ -9,20 +9,20 @@ topic_status: TODO
 
 ## Intro
 
-Because `protoprimer` restarts `python` and communicates state via [FT_08_92_69_92.env_var.md][FT_08_92_69_92.env_var.md],
-it is important to manage them at [FT_07_55_61_77.exit_point.md][FT_07_55_61_77.exit_point.md]-s
+Because `protoprimer` restarts `python` and communicates state via [env_var][FT_08_92_69_92.env_var.md],
+it is important to manage them at [exit_point][FT_07_55_61_77.exit_point.md]-s
 to avoid disrupting one `protoprimer` invocation by another.
 
-The idea is to ensure no env vars leak through [FT_07_55_61_77.exit_point.md][FT_07_55_61_77.exit_point.md]-s,
+The idea is to ensure no env vars leak through [exit_point][FT_07_55_61_77.exit_point.md]-s,
 otherwise, there can be a need to save them inside some sort of stack and restore them (to avoid overwriting).
 
-Custom steps extending [FT_85_17_35_21.boot_env.md][FT_85_17_35_21.boot_env.md] should guarantee
-to clean the env vars at [FT_07_55_61_77.exit_point.md][FT_07_55_61_77.exit_point.md] themselves.
+Custom steps extending [boot_env][FT_85_17_35_21.boot_env.md] should guarantee
+to clean the env vars at [exit_point][FT_07_55_61_77.exit_point.md] themselves.
 
 ## See also
 
-[FT_96_50_58_75.context_propagation.md][FT_96_50_58_75.context_propagation.md] has the opposite purpose
-to provide the abs path to [FT_90_65_67_62.proto_code.md][FT_90_65_67_62.proto_code.md].
+[context_propagation][FT_96_50_58_75.context_propagation.md] has the opposite purpose
+to provide the abs path to [proto_code][FT_90_65_67_62.proto_code.md].
 But it is done via `python` global variable which does not leek it to any child process via env vars.
 
 [FT_08_92_69_92.env_var.md]: FT_08_92_69_92.env_var.md

--- a/doc/feature_topic/FT_68_54_41_96.state_dependency.md
+++ b/doc/feature_topic/FT_68_54_41_96.state_dependency.md
@@ -1,6 +1,6 @@
 ---
 feature_topic: FT_68_54_41_96
-topic_title: state dependency
+topic_title: state_dependency
 topic_status: TODO
 ---
 
@@ -22,8 +22,8 @@ There is no domain-specific lang used by `protoprime` to define those states (ev
 
 Each state is identified by a string (state name).
 
-[FT_90_65_67_62.proto_code.md][FT_90_65_67_62.proto_code.md] defines states only
-for "proto" phase (see [FT_14_52_73_23.primer_runtime.md][FT_14_52_73_23.primer_runtime.md]).
+[proto_code][FT_90_65_67_62.proto_code.md] defines states only
+for "proto" phase (see [primer_runtime][FT_14_52_73_23.primer_runtime.md]).
 
 Client code may use that framework to implement client-specific states.
 

--- a/doc/feature_topic/FT_72_45_12_06.python_executable.md
+++ b/doc/feature_topic/FT_72_45_12_06.python_executable.md
@@ -1,6 +1,6 @@
 ---
 feature_topic: FT_72_45_12_06
-topic_title: python executable
+topic_title: python_executable
 topic_status: TODO
 ---
 
@@ -11,7 +11,7 @@ TODO: Add separate FS for the concept of `StateStride`.
 
 ## Intro
 
-The stand-alone [FT_90_65_67_62.proto_code.md][FT_90_65_67_62.proto_code.md]
+The stand-alone [proto_code][FT_90_65_67_62.proto_code.md]
 is designed to be run by any `python` executable (available in `PATH`).
 
 Eventually, based on the target client repo requirements, it must become:
@@ -33,12 +33,12 @@ TODO: TODO_50_98_96_87.support_windows.md: To support Windows, `os.execve` will 
 ## Details
 
 That initial executable is unpredictable:
-*   It may be any in the user `PATH` env var (via [FT_02_89_37_65.shebang_line.md][FT_02_89_37_65.shebang_line.md]).
+*   It may be any in the user `PATH` env var (via [shebang_line][FT_02_89_37_65.shebang_line.md]).
 *   It may be any specified by the user directly.
 
-Moreover, once `venv` is initialized, [FT_90_65_67_62.proto_code.md][FT_90_65_67_62.proto_code.md] also needs
+Moreover, once `venv` is initialized, [proto_code][FT_90_65_67_62.proto_code.md] also needs
 to switch to required `python` inside that `venv` to install dependencies there
-(see [FT_14_52_73_23.primer_runtime.md][FT_14_52_73_23.primer_runtime.md]).
+(see [primer_runtime][FT_14_52_73_23.primer_runtime.md]).
 
 `proto_primer` switches progressively to next `python` binary (starts a new process)
 communicating that progress via `EnvVar.var_PROTOPRIMER_PY_EXEC`.

--- a/doc/feature_topic/FT_73_95_31_84.venv_driver.md
+++ b/doc/feature_topic/FT_73_95_31_84.venv_driver.md
@@ -1,6 +1,6 @@
 ---
 feature_topic: FT_73_95_31_84
-topic_title: venv driver
+topic_title: venv_driver
 topic_status: TODO
 ---
 

--- a/doc/feature_topic/FT_74_10_40_33.DAG_extension.md
+++ b/doc/feature_topic/FT_74_10_40_33.DAG_extension.md
@@ -1,19 +1,19 @@
 ---
 feature_topic: FT_74_10_40_33
-topic_title: DAG extension
+topic_title: DAG_extension
 topic_status: TODO
 ---
 
 
 # FT_74_10_40_33.DAG_extension
 
-TODO: See also [UC_10_80_27_57.extend_dag.md][UC_10_80_27_57.extend_dag.md] - should it be merged here?
+TODO: See also [extend_DAG][UC_10_80_27_57.extend_DAG.md] - should it be merged here?
 
 ## How does DAG extension work?
 
-The [FT_75_87_82_46.entry_script.md][FT_75_87_82_46.entry_script.md] has to:
-*   transition to `meta` [FT_14_52_73_23.primer_runtime.md][FT_14_52_73_23.primer_runtime.md] first
-*   implement [FT_62_88_55_10.CLI_compatibility.md][FT_62_88_55_10.CLI_compatibility.md]
+The [entry_script][FT_75_87_82_46.entry_script.md] has to:
+*   transition to `meta` [primer_runtime][FT_14_52_73_23.primer_runtime.md] first
+*   implement [CLI_compatibility][FT_62_88_55_10.CLI_compatibility.md]
 
 ## How to specify target state available only in `meta` runtime?
 
@@ -31,4 +31,4 @@ In other words, whatever `runtime_meta` does (whatever names it has) is irreleva
 [FT_75_87_82_46.entry_script.md]: FT_75_87_82_46.entry_script.md
 [FT_74_10_40_33.DAG_extension.md]: FT_74_10_40_33.DAG_extension.md
 [FT_62_88_55_10.CLI_compatibility.md]: FT_62_88_55_10.CLI_compatibility.md
-[UC_10_80_27_57.extend_dag.md]: ../use_case/UC_10_80_27_57.extend_DAG.md
+[UC_10_80_27_57.extend_DAG.md]: ../use_case/UC_10_80_27_57.extend_DAG.md

--- a/doc/feature_topic/FT_75_87_82_46.entry_script.md
+++ b/doc/feature_topic/FT_75_87_82_46.entry_script.md
@@ -1,6 +1,6 @@
 ---
 feature_topic: FT_75_87_82_46
-topic_title: entry script
+topic_title: entry_script
 topic_status: TODO
 ---
 
@@ -31,7 +31,7 @@ In short, they are **primitive delegators**.
 
 Entry scripts should be kept primitive because they are harder to test:
 *   they are outside of `venv` which makes it difficlut to execute reliably
-*   they can be shell scripts that lack test-ability (see [FT_44_72_60_67.python_vs_shell.md][FT_44_72_60_67.python_vs_shell.md])
+*   they can be shell scripts that lack test-ability (see [python_vs_shell][FT_44_72_60_67.python_vs_shell.md])
 
 Ideally, they serve as only as an entry point to launch the rest of the code
 (which is supposed to be inside `venv` within installed modules).
@@ -39,7 +39,7 @@ Ideally, they serve as only as an entry point to launch the rest of the code
 ## How to delegate?
 
 Entry scripts are started by the user shell and their `python` is unpredictable -
-see [FT_72_45_12_06.python_executable.md][FT_72_45_12_06.python_executable.md].
+see [python_executable][FT_72_45_12_06.python_executable.md].
 
 The main job for entry scripts is to figure out how to delegate the execution to a module inside `venv`.
 
@@ -48,23 +48,23 @@ Options for `venv` activation:
 *   The fastest option is to use (generated) shebang pointing to a `python` binary from `venv`.
 
     This is a less flexible approach with limits on the maximum length of shebang line -
-    see [FT_02_89_37_65.shebang_line.md][FT_02_89_37_65.shebang_line.md].
+    see [shebang_line][FT_02_89_37_65.shebang_line.md].
 
 *   A slower alternative is to run a helper function which does the job.
 
-    This is what `protoprimer` is designed for - see [FT_90_65_67_62.proto_code.md][FT_90_65_67_62.proto_code.md].
+    This is what `protoprimer` is designed for - see [proto_code][FT_90_65_67_62.proto_code.md].
 
     In fact, there are two helper functions - see:
-    *   [FT_58_74_37_70.boot_vs_start.md][FT_58_74_37_70.boot_vs_start.md]
-    *   [FT_05_08_64_67.start_app.md][FT_05_08_64_67.start_app.md]
-    *   [FT_85_17_35_21.boot_env.md][FT_85_17_35_21.boot_env.md]
+    *   [boot_vs_start][FT_58_74_37_70.boot_vs_start.md]
+    *   [start_app][FT_05_08_64_67.start_app.md]
+    *   [boot_env][FT_85_17_35_21.boot_env.md]
 
-TODO: Implement [UC_71_59_90_97.generated_entry_script.md][UC_71_59_90_97.generated_entry_script.md].
+TODO: Implement [generated_entry_script][UC_71_59_90_97.generated_entry_script.md].
 
 ## Special case: `proto_code`
 
 It is possible to run `proto_code` as an entry script directly
-(see min [FT_59_95_81_63.env_layout.md][FT_59_95_81_63.env_layout.md]), for example:
+(see min [env_layout][FT_59_95_81_63.env_layout.md]), for example:
 
 ```sh
 ./cmd/proto_code/proto_kernel.py -h

--- a/doc/feature_topic/FT_77_15_06_50.dynamic_DAG.md
+++ b/doc/feature_topic/FT_77_15_06_50.dynamic_DAG.md
@@ -1,6 +1,6 @@
 ---
 feature_topic: FT_77_15_06_50
-topic_title: dynamic DAG
+topic_title: dynamic_DAG
 topic_status: TODO
 ---
 
@@ -9,7 +9,7 @@ topic_status: TODO
 
 ## Intro
 
-The DAG builder constructs sub-graphs based on the current [`GraphCoordinates`][FT_25_62_13_55.entry_func.md].
+The DAG builder constructs sub-graphs based on the current [entry_func][FT_25_62_13_55.entry_func.md].
 
 This eliminates complex `if/else` logic within `EnvState`-s to avoid `python` restarts for specialized
 modes like `EntryFunc.func_start_app` or `EntryFunc.func_call_lib`.
@@ -21,7 +21,7 @@ For example:
 *   while `EntryFunc.func_boot_env` should process CLI args, run through `python` restarts, and create `venv`
 
 See also a more specific case:
-[UC_54_26_66_63.lib_access_to_config_data.md][UC_54_26_66_63.lib_access_to_config_data.md]
+[lib_access_to_config_data][UC_54_26_66_63.lib_access_to_config_data.md]
 
 ## DAG sub-graphs
 
@@ -69,12 +69,12 @@ For example, the role of `proto_main` shifts to:
 
 Separate:
 
-*   `EntryFunc`: known immediately via the entry point - see [FT_25_62_13_55.entry_func.md][FT_25_62_13_55.entry_func.md]:
+*   `EntryFunc`: known immediately via the entry point - see [entry_func][FT_25_62_13_55.entry_func.md]:
     *   `boot_env` (CLI processing)
     *   `start_app` (no CLI processing)
     *   API library (no CLI processing, no `python` restarts)
     *   direct `proto_main` execution (similar to `env_bootstrapper`)
-*   `SubCommand`: known only after CLI argument processing - see [FT_11_27_29_83.sub_command.md][FT_11_27_29_83.sub_command.md]
+*   `SubCommand`: known only after CLI argument processing - see [sub_command][FT_11_27_29_83.sub_command.md]
 
 TODO: FT_77_15_06_50.dynamic_DAG.md:
       `sub_command` should affect how `GraphCoordinates` are set, but should not be a coordinate itself.
@@ -84,7 +84,7 @@ TODO: FT_77_15_06_50.dynamic_DAG.md:
 State names should remain stable and known at the start of a `StateStride`,
 though they can be extended in an append-only fashion.
 
-See [FT_68_54_41_96.state_dependency.md][FT_68_54_41_96.state_dependency.md].
+See [state_dependency][FT_68_54_41_96.state_dependency.md].
 
 ## Open TODOs
 

--- a/doc/feature_topic/FT_83_60_72_19.test_perimeter.md
+++ b/doc/feature_topic/FT_83_60_72_19.test_perimeter.md
@@ -1,6 +1,6 @@
 ---
 feature_topic: FT_83_60_72_19
-topic_title: test perimeter
+topic_title: test_perimeter
 topic_status: TODO
 ---
 
@@ -51,7 +51,7 @@ Due to the nature of the `protoprimer`, this test mode affects some prod code.
 To make it explicit, all such prod code extensions work with `EnvVar.var_PROTOPRIMER_MOCKED_RESTART`.
 
 The main condition: the `venv` of the test runner is not escape-able.
-This means [FT_90_65_67_62.proto_code.md][FT_90_65_67_62.proto_code.md] cannot be selected automatically
+This means [proto_code][FT_90_65_67_62.proto_code.md] cannot be selected automatically
 (`proto_code` will always be from the `venv` of the test runner).
 This means `EnvVar.var_PROTOPRIMER_PROTO_CODE` must also be set for such tests for the bootstrap process to complete.
 

--- a/doc/feature_topic/FT_84_11_73_28.supported_python_versions.md
+++ b/doc/feature_topic/FT_84_11_73_28.supported_python_versions.md
@@ -1,6 +1,6 @@
 ---
 feature_topic: FT_84_11_73_28
-topic_title: supported python versions
+topic_title: supported_python_versions
 topic_status: TEST
 ---
 

--- a/doc/feature_topic/FT_85_17_35_21.boot_env.md
+++ b/doc/feature_topic/FT_85_17_35_21.boot_env.md
@@ -15,9 +15,9 @@ During this function, `protoprimer`:
 *   Populates `venv` with dependencies.
 *   Passes control to custom client bootstrap steps.
 
-The case is indicated by `EntryFunc.func_boot_env` (see [FT_25_62_13_55.entry_func.md][FT_25_62_13_55.entry_func.md]).
+The case is indicated by `EntryFunc.func_boot_env` (see [entry_func][FT_25_62_13_55.entry_func.md]).
 
-See also [FT_58_74_37_70.boot_vs_start.md][FT_58_74_37_70.boot_vs_start.md].
+See also [boot_vs_start][FT_58_74_37_70.boot_vs_start.md].
 
 [FT_25_62_13_55.entry_func.md]: FT_25_62_13_55.entry_func.md
 [FT_58_74_37_70.boot_vs_start.md]: FT_58_74_37_70.boot_vs_start.md

--- a/doc/feature_topic/FT_85_17_35_21.call_lib.md
+++ b/doc/feature_topic/FT_85_17_35_21.call_lib.md
@@ -1,6 +1,6 @@
 ---
 feature_topic: FT_85_17_35_21
-topic_title: call lib
+topic_title: call_lib
 topic_status: TODO
 ---
 
@@ -9,11 +9,11 @@ topic_status: TODO
 
 ## Intro
 
-There are cases when `protoprimer` (its [FT_87_17_49_36.kernel_copy.md][FT_87_17_49_36.kernel_copy.md])
+There are cases when `protoprimer` (its [kernel_copy][FT_87_17_49_36.kernel_copy.md])
 can be used as a library.
 
-For example, to extract [FT_19_44_42_19.effective_config.md][FT_19_44_42_19.effective_config.md],
-we can execute the same DAG (rather than traversing [FT_89_41_35_82.conf_leap.md][FT_89_41_35_82.conf_leap.md]).
+For example, to extract [effective_config][FT_19_44_42_19.effective_config.md],
+we can execute the same DAG (rather than traversing [conf_leap][FT_89_41_35_82.conf_leap.md]).
 
 [FT_87_17_49_36.kernel_copy.md]: FT_87_17_49_36.kernel_copy.md
 [FT_19_44_42_19.effective_config.md]: FT_19_44_42_19.effective_config.md

--- a/doc/feature_topic/FT_87_17_49_36.kernel_copy.md
+++ b/doc/feature_topic/FT_87_17_49_36.kernel_copy.md
@@ -1,6 +1,6 @@
 ---
 feature_topic: FT_87_17_49_36
-topic_title: kernel copy
+topic_title: kernel_copy
 topic_status: TODO
 ---
 

--- a/doc/feature_topic/FT_89_41_35_82.conf_leap.md
+++ b/doc/feature_topic/FT_89_41_35_82.conf_leap.md
@@ -1,6 +1,6 @@
 ---
 feature_topic: FT_89_41_35_82
-topic_title: conf leap
+topic_title: conf_leap
 topic_status: TODO
 ---
 
@@ -9,7 +9,7 @@ topic_status: TODO
 
 ## Intro
 
-There are several configuration leaps used by [FT_90_65_67_62.proto_code.md][FT_90_65_67_62.proto_code.md].
+There are several configuration leaps used by [proto_code][FT_90_65_67_62.proto_code.md].
 
 Essentially, going through all the conf leaps is the way to load all the config info.
 
@@ -85,7 +85,7 @@ Configuration leaps are ordered (from first to last).
 
     It may only from command line args, env vars, or hard-coded values.
 
-    See [FT_02_89_37_65.shebang_line.md][FT_02_89_37_65.shebang_line.md].
+    See [shebang_line][FT_02_89_37_65.shebang_line.md].
 
 *   `leap_primer`
 
@@ -103,17 +103,17 @@ Configuration leaps are ordered (from first to last).
     client code needs to deal with.
 
     This is also the leap that gives access to `source_local` config.
-    See also [FT_23_37_64_44.global_vs_local.md][FT_23_37_64_44.global_vs_local.md].
+    See also [global_vs_local][FT_23_37_64_44.global_vs_local.md].
 
 *   `leap_derived`
 
     This is effective configuration that applies overrides of `leap_client` field values by `leap_env` ones.
 
-    See [FT_00_22_19_59.derived_config.md][FT_00_22_19_59.derived_config.md].
+    See [derived_config][FT_00_22_19_59.derived_config.md].
 
 ## Configuration files
 
-Depending on the [FT_59_95_81_63.env_layout.md][FT_59_95_81_63.env_layout.md], all configuration leaps
+Depending on the [env_layout][FT_59_95_81_63.env_layout.md], all configuration leaps
 may be provided in a single file or separate ones.
 
 [leap_primer]: cmd/proto_code/proto_kernel.json

--- a/doc/feature_topic/FT_90_65_67_62.proto_code.md
+++ b/doc/feature_topic/FT_90_65_67_62.proto_code.md
@@ -12,7 +12,7 @@ topic_status: TODO
 If you start with an absolutely empty environment, there is nothing you can run.
 
 To start running `protoprimer`, you need at least:
-*   minimal [FT_22_11_94_65.bootstrap_precondition.md][FT_22_11_94_65.bootstrap_precondition.md]
+*   minimal [bootstrap_precondition][FT_22_11_94_65.bootstrap_precondition.md]
 *   `proto_code` (described now)
 
 ## What is `proto_code`?
@@ -28,15 +28,15 @@ A user should be able to clone the client repo and prime the environment by a si
 ```
 
 <!--
-TODO: Explain starting via [FT_75_87_82_46.entry_script.md][FT_75_87_82_46.entry_script.md].
+TODO: Explain starting via [entry_script][FT_75_87_82_46.entry_script.md].
 -->
 
 What the client does **not** want is to maintain any code outside the client-specific concerns.
 
 What exactly is the command the user has to run (`./prime` or something else)
 depends on the client configuration of:
-*   [FT_59_95_81_63.env_layout.md][FT_59_95_81_63.env_layout.md]
-*   [FT_75_87_82_46.entry_script.md][FT_75_87_82_46.entry_script.md]
+*   [env_layout][FT_59_95_81_63.env_layout.md]
+*   [entry_script][FT_75_87_82_46.entry_script.md]
 
 [FT_22_11_94_65.bootstrap_precondition.md]: FT_22_11_94_65.bootstrap_precondition.md
 [FT_90_65_67_62.proto_code.md]: FT_90_65_67_62.proto_code.md

--- a/doc/feature_topic/FT_92_51_35_07.local_env_link.md
+++ b/doc/feature_topic/FT_92_51_35_07.local_env_link.md
@@ -21,8 +21,8 @@ all paths to access any of the files there can be stable
 
 ## See also
 
-*   [FT_23_37_64_44.global_vs_local.md][FT_23_37_64_44.global_vs_local.md] for `global` and `local` configs.
-*   [FT_89_41_35_82.conf_leap.md][FT_89_41_35_82.conf_leap.md] for config leaps.
+*   [global_vs_local][FT_23_37_64_44.global_vs_local.md] for `global` and `local` configs.
+*   [conf_leap][FT_89_41_35_82.conf_leap.md] for config leaps.
 
 [FT_23_37_64_44.global_vs_local.md]: FT_23_37_64_44.global_vs_local.md
 [FT_89_41_35_82.conf_leap.md]: FT_89_41_35_82.conf_leap.md

--- a/doc/feature_topic/FT_93_57_03_75.app_vs_lib.md
+++ b/doc/feature_topic/FT_93_57_03_75.app_vs_lib.md
@@ -1,6 +1,6 @@
 ---
 feature_topic: FT_93_57_03_75
-topic_title: app vs lib
+topic_title: app_vs_lib
 topic_status: TODO
 ---
 
@@ -9,39 +9,39 @@ topic_status: TODO
 
 TODO: TODO_03_22_24_33.consolidate_sub_command_and_entry_func_docs.md:
 The significance of the difference between `app` vs `lib` has been obsoleted by
-[FT_58_74_37_70.boot_vs_start.md][FT_58_74_37_70.boot_vs_start.md] -
+[boot_vs_start][FT_58_74_37_70.boot_vs_start.md] -
 effectively, the `protoprimer` during `proto` runtime is used as `app` only
 (either as env bootstrapper or app starter).
 
-TODO: Update it after adding [FT_85_17_35_21.call_lib.md][FT_85_17_35_21.call_lib.md].
+TODO: Update it after adding [call_lib][FT_85_17_35_21.call_lib.md].
 
 ## Intro
 
-[FT_90_65_67_62.proto_code.md][FT_90_65_67_62.proto_code.md] is designed to run without `venv`.
+[proto_code][FT_90_65_67_62.proto_code.md] is designed to run without `venv`.
 
 This makes it useful for scripts **not only** as an application
-(see [FT_58_74_37_70.boot_vs_start.md][FT_58_74_37_70.boot_vs_start.md]),
+(see [boot_vs_start][FT_58_74_37_70.boot_vs_start.md]),
 but also as an initial library for basic functionality before `venv` is available.
 
 ## `proto_code`: app vs lib
 
 *   `app` = application
 
-    This means that the [FT_75_87_82_46.entry_script.md][FT_75_87_82_46.entry_script.md] being executed
-    is meant to traverse [FT_68_54_41_96.state_dependency.md][FT_68_54_41_96.state_dependency.md] in
-    one of the [FT_11_27_29_83.sub_command.md][FT_11_27_29_83.sub_command.md].
+    This means that the [entry_script][FT_75_87_82_46.entry_script.md] being executed
+    is meant to traverse [state_dependency][FT_68_54_41_96.state_dependency.md] in
+    one of the [sub_command][FT_11_27_29_83.sub_command.md].
 
     Effectively, the script has to execute `proto_main` function from `proto_code` (see `protoprimer.primer_kernel`).
-    See [FT_58_74_37_70.boot_vs_start.md][FT_58_74_37_70.boot_vs_start.md].
+    See [boot_vs_start][FT_58_74_37_70.boot_vs_start.md].
 
 *   `lib` = library
 
-    When `proto_code` is used as a library, the [FT_75_87_82_46.entry_script.md][FT_75_87_82_46.entry_script.md]
+    When `proto_code` is used as a library, the [entry_script][FT_75_87_82_46.entry_script.md]
     can use anything `proto_code` offers.
 
 ## See also
 
-*   [FT_25_62_13_55.entry_func.md][FT_25_62_13_55.entry_func.md]
+*   [entry_func][FT_25_62_13_55.entry_func.md]
 
 [FT_90_65_67_62.proto_code.md]: FT_90_65_67_62.proto_code.md
 [FT_75_87_82_46.entry_script.md]: FT_75_87_82_46.entry_script.md

--- a/doc/feature_topic/FT_96_50_58_75.context_propagation.md
+++ b/doc/feature_topic/FT_96_50_58_75.context_propagation.md
@@ -1,6 +1,6 @@
 ---
 feature_topic: FT_96_50_58_75
-topic_title: context propagation
+topic_title: context_propagation
 topic_status: TODO
 ---
 
@@ -9,18 +9,18 @@ topic_status: TODO
 
 ## Intro
 
-Because `protoprimer` already needs some config to run (see [FT_00_22_19_59.derived_config.md][FT_00_22_19_59.derived_config.md]),
+Because `protoprimer` already needs some config to run (see [derived_config][FT_00_22_19_59.derived_config.md]),
 it can be reused by other scripts.
 
-To reuse config, scripts rely on the same bootstrap mechanism to traverse and load it via [FT_89_41_35_82.conf_leap.md][FT_89_41_35_82.conf_leap.md].
-This requires an abs path to [FT_90_65_67_62.proto_code.md][FT_90_65_67_62.proto_code.md].
+To reuse config, scripts rely on the same bootstrap mechanism to traverse and load it via [conf_leap][FT_89_41_35_82.conf_leap.md].
+This requires an abs path to [proto_code][FT_90_65_67_62.proto_code.md].
 
-At the same time, due to [FT_66_02_54_56.context_isolation.md][FT_66_02_54_56.context_isolation.md],
+At the same time, due to [context_isolation][FT_66_02_54_56.context_isolation.md],
 `PROTOPRIMER_PROTO_CODE` env var is removed before passing control to any client code.
 This is correct as env vars leak to child processes
 (and `PROTOPRIMER_PROTO_CODE` will unintentionally affect any other `protoprimer` code started subsequently).
 
-To pass the knowledge of the [FT_90_65_67_62.proto_code.md][FT_90_65_67_62.proto_code.md] abs path to
+To pass the knowledge of the [proto_code][FT_90_65_67_62.proto_code.md] abs path to
 the client script without affecting its child processes,
 `protoprimer` sets a global variable accessible via `protoprimer.primer_kernel.get_proto_kernel_abs_path`
 that can be used for any `protoprimer` (or `metaprimer`) API.
@@ -30,7 +30,7 @@ the global - when set, the bootstrapper uses it instead of the global variable.
 
 ## See also
 
-This feature provides support to [UC_54_26_66_63.lib_access_to_config_data.md][UC_54_26_66_63.lib_access_to_config_data.md].
+This feature provides support to [lib_access_to_config_data][UC_54_26_66_63.lib_access_to_config_data.md].
 
 [FT_00_22_19_59.derived_config.md]: FT_00_22_19_59.derived_config.md
 [FT_89_41_35_82.conf_leap.md]: FT_89_41_35_82.conf_leap.md

--- a/doc/feature_topic/FT_98_06_56_18.version_pinning.md
+++ b/doc/feature_topic/FT_98_06_56_18.version_pinning.md
@@ -1,6 +1,6 @@
 ---
 feature_topic: FT_98_06_56_18
-topic_title: version pinning
+topic_title: version_pinning
 topic_status: TODO
 ---
 

--- a/doc/feature_topic/FT_99_89_51_06.venv_shell.md
+++ b/doc/feature_topic/FT_99_89_51_06.venv_shell.md
@@ -29,7 +29,7 @@ Provide a `venv_shell` command which does this automatically.
 ## Implementation
 
 There is no (easy) way to avoid starting the bootstrap process specifically to
-go through the [FT_89_41_35_82.conf_leap.md][FT_89_41_35_82.conf_leap.md] until path to `venv` is identified.
+go through the [conf_leap][FT_89_41_35_82.conf_leap.md] until path to `venv` is identified.
 
 But, to make start time quicker, the package installation step can be avoided.
 Also, to keep output clean, the default verbosity must be changed to "quiet".
@@ -39,11 +39,11 @@ This is achieved via setting specific environment variables:
 
 TODO: update when implemented:
 Another problem is CLI of the bootstrap is incompatible with passing arbitrary CLI args to the `venv` shell.
-See [FT_62_88_55_10.CLI_compatibility.md][FT_62_88_55_10.CLI_compatibility.md].
+See [CLI_compatibility][FT_62_88_55_10.CLI_compatibility.md].
 
 TODO: update when implemented:
 To make it work, the bootstrap process has to support a special arg which passes those arbitrary CLI args
-through multiple invocations of [FT_72_45_12_06.python_executable.md][FT_72_45_12_06.python_executable.md].
+through multiple invocations of [python_executable][FT_72_45_12_06.python_executable.md].
 TODO: Which one is this?
 
 [FT_89_41_35_82.conf_leap.md]: FT_89_41_35_82.conf_leap.md

--- a/doc/use_case/UC_09_61_98_94.installer_pip_vs_uv.md
+++ b/doc/use_case/UC_09_61_98_94.installer_pip_vs_uv.md
@@ -1,6 +1,6 @@
 ---
 use_case: UC_09_61_98_94
-case_title: installer pip vs uv
+case_title: installer_pip_vs_uv
 case_status: TODO
 ---
 

--- a/doc/use_case/UC_10_80_27_57.extend_DAG.md
+++ b/doc/use_case/UC_10_80_27_57.extend_DAG.md
@@ -1,13 +1,13 @@
 ---
 use_case: UC_10_80_27_57
-case_title: extend DAG
+case_title: extend_DAG
 case_status: TODO
 ---
 
 
 # UC_10_80_27_57.extend_DAG
 
-TODO: See also [FT_74_10_40_33.DAG_extension.md][FT_74_10_40_33.DAG_extension.md] - should it be merged here?
+TODO: See also [DAG_extension][FT_74_10_40_33.DAG_extension.md] - should it be merged here?
 
 ## Intro
 
@@ -86,7 +86,7 @@ graph TD
 
 ## Other cases
 
-*   [UC_27_40_17_59.replace_by_new_and_use_old.md][UC_27_40_17_59.replace_by_new_and_use_old.md]
+*   [replace_by_new_and_use_old][UC_27_40_17_59.replace_by_new_and_use_old.md]
 
 [UC_27_40_17_59.replace_by_new_and_use_old.md]: UC_27_40_17_59.replace_by_new_and_use_old.md
 [FT_74_10_40_33.DAG_extension.md]: ../feature_topic/FT_74_10_40_33.DAG_extension.md

--- a/doc/use_case/UC_27_40_17_59.replace_by_new_and_use_old.md
+++ b/doc/use_case/UC_27_40_17_59.replace_by_new_and_use_old.md
@@ -1,6 +1,6 @@
 ---
 use_case: UC_27_40_17_59
-case_title: replace by new and use old
+case_title: replace_by_new_and_use_old
 case_status: TODO
 ---
 

--- a/doc/use_case/UC_36_72_11_12.pipe_to_execute_with_activated_venv.md
+++ b/doc/use_case/UC_36_72_11_12.pipe_to_execute_with_activated_venv.md
@@ -1,6 +1,6 @@
 ---
 use_case: UC_36_72_11_12
-case_title: pipe to execute with activated `venv`
+case_title: pipe_to_execute_with_activated_venv
 case_status: TODO
 ---
 

--- a/doc/use_case/UC_39_44_27_45.single_proto_kernel_per_repo.md
+++ b/doc/use_case/UC_39_44_27_45.single_proto_kernel_per_repo.md
@@ -1,6 +1,6 @@
 ---
 use_case: UC_39_44_27_45
-case_title: single proto kernel per repo
+case_title: single_proto_kernel_per_repo
 case_status: TODO
 ---
 
@@ -8,16 +8,16 @@ case_status: TODO
 # UC_39_44_27_45.single_proto_kernel_per_repo
 
 In cases where one repo contains multiple client projects, or multiple `venv`-s,
-it should be possible to have a single copy of [FT_90_65_67_62.proto_code.md][FT_90_65_67_62.proto_code.md]
+it should be possible to have a single copy of [proto_code][FT_90_65_67_62.proto_code.md]
 to serve them all.
 
 ## Implementation choices
 
 One of the most straightforward solutions is to use symlinks to the single copy.
 
-However, the more flexible approach is to use different [FT_75_87_82_46.entry_script.md][FT_75_87_82_46.entry_script.md].
-This allows specifying different [FT_02_89_37_65.shebang_line.md][FT_02_89_37_65.shebang_line.md] with its own
-[FT_08_92_69_92.env_var.md][FT_08_92_69_92.env_var.md].
+However, the more flexible approach is to use different [entry_script][FT_75_87_82_46.entry_script.md].
+This allows specifying different [shebang_line][FT_02_89_37_65.shebang_line.md] with its own
+[env_var][FT_08_92_69_92.env_var.md].
 
 [FT_90_65_67_62.proto_code.md]: ../feature_topic/FT_90_65_67_62.proto_code.md
 [FT_75_87_82_46.entry_script.md]: ../feature_topic/FT_75_87_82_46.entry_script.md

--- a/doc/use_case/UC_44_82_07_30.requirements_lock.md
+++ b/doc/use_case/UC_44_82_07_30.requirements_lock.md
@@ -1,6 +1,6 @@
 ---
 use_case: UC_44_82_07_30
-case_title: requirements lock
+case_title: requirements_lock
 case_status: TODO
 ---
 
@@ -13,6 +13,6 @@ keywords: requirements.txt, constraints.txt, version pinning, version lock
 *   it should provide the exact version of packages
 *   while the client dependency specs (e.g., in `pyproject.toml`) should provide version ranges
 
-See also [UC_61_12_90_59.upgrade_venv.md][UC_61_12_90_59.upgrade_venv.md].
+See also [upgrade_venv][UC_61_12_90_59.upgrade_venv.md].
 
 [UC_61_12_90_59.upgrade_venv.md]: UC_61_12_90_59.upgrade_venv.md

--- a/doc/use_case/UC_48_17_11_65.container_friendly.md
+++ b/doc/use_case/UC_48_17_11_65.container_friendly.md
@@ -1,6 +1,6 @@
 ---
 use_case: UC_48_17_11_65
-case_title: container friendly
+case_title: container_friendly
 case_status: TODO
 ---
 

--- a/doc/use_case/UC_52_87_82_92.conditional_auto_update.md
+++ b/doc/use_case/UC_52_87_82_92.conditional_auto_update.md
@@ -1,13 +1,13 @@
 ---
 use_case: UC_52_87_82_92
-case_title: conditional auto update
+case_title: conditional_auto_update
 case_status: TODO
 ---
 
 
 # UC_52_87_82_92.conditional_auto_update
 
-It should be possible to disable auto-update for [FT_90_65_67_62.proto_code.md][FT_90_65_67_62.proto_code.md].
+It should be possible to disable auto-update for [proto_code][FT_90_65_67_62.proto_code.md].
 
 TODO: But what is the use case?
       If updates are disabled, then the stand-alone version will diverge from the packaged version.

--- a/doc/use_case/UC_54_26_66_63.lib_access_to_config_data.md
+++ b/doc/use_case/UC_54_26_66_63.lib_access_to_config_data.md
@@ -1,6 +1,6 @@
 ---
 use_case: UC_54_26_66_63
-case_title: lib access to config data
+case_title: lib_access_to_config_data
 case_status: DONE
 ---
 
@@ -12,30 +12,30 @@ case_status: DONE
 There should be a way to access `protoprimer` config data for reuse in other (entry) scripts.
 
 Other scripts must always start as `entry_script`-s
-(see [FT_75_87_82_46.entry_script.md][FT_75_87_82_46.entry_script.md]).
+(see [entry_script][FT_75_87_82_46.entry_script.md]).
 
 Using the data in entry script means `protoprimer` acts as a `lib` with API to provide that data.
 
-The access to the config data depends on [FT_89_41_35_82.conf_leap.md][FT_89_41_35_82.conf_leap.md]
+The access to the config data depends on [conf_leap][FT_89_41_35_82.conf_leap.md]
 starting from the path to `proto_code`.
 
 Normally, detection of the reliable path to `proto_code`
-requires [FT_28_25_63_06.isolated_python.md][FT_28_25_63_06.isolated_python.md]
+requires [isolated_python][FT_28_25_63_06.isolated_python.md]
 which implies re-starting `python` with `-I` option.
 
 ## Solution
 
 The entry scripts can avoid `python` re-start by providing the path to `proto_code`.
 
-The entry scripts are already running [FT_28_25_63_06.isolated_python.md][FT_28_25_63_06.isolated_python.md].
+The entry scripts are already running [isolated_python][FT_28_25_63_06.isolated_python.md].
 
 `protoprimer` simply has to support running the DAG through
-the [FT_89_41_35_82.conf_leap.md][FT_89_41_35_82.conf_leap.md] without doing all things it does for
-[FT_85_17_35_21.boot_env.md][FT_85_17_35_21.boot_env.md].
+the [conf_leap][FT_89_41_35_82.conf_leap.md] without doing all things it does for
+[boot_env][FT_85_17_35_21.boot_env.md].
 
 ## See also
 
-[FT_96_50_58_75.context_propagation.md][FT_96_50_58_75.context_propagation.md] provides the mechanism
+[context_propagation][FT_96_50_58_75.context_propagation.md] provides the mechanism
 and function `protoprimer.get_proto_kernel_abs_path` to support this use case.
 
 [FT_75_87_82_46.entry_script.md]: ../feature_topic/FT_75_87_82_46.entry_script.md

--- a/doc/use_case/UC_60_43_19_67.simple_bootstrap.md
+++ b/doc/use_case/UC_60_43_19_67.simple_bootstrap.md
@@ -1,6 +1,6 @@
 ---
 use_case: UC_60_43_19_67
-case_title: simple bootstrap
+case_title: simple_bootstrap
 case_status: TEST
 ---
 

--- a/doc/use_case/UC_61_12_90_59.upgrade_venv.md
+++ b/doc/use_case/UC_61_12_90_59.upgrade_venv.md
@@ -1,6 +1,6 @@
 ---
 use_case: UC_61_12_90_59
-case_title: upgrade `venv`
+case_title: upgrade_venv
 case_status: TEST
 ---
 
@@ -9,9 +9,9 @@ case_status: TEST
 
 A user should be able to re-compute dependency versions (only via spec in `pyproject.toml`) without `constraints.txt`.
 
-This feature is implemented via [FT_42_03_79_73.reboot_env.md][FT_42_03_79_73.reboot_env.md].
+This feature is implemented via [reboot_env][FT_42_03_79_73.reboot_env.md].
 
-See also [UC_44_82_07_30.requirements_lock.md][UC_44_82_07_30.requirements_lock.md].
+See also [requirements_lock][UC_44_82_07_30.requirements_lock.md].
 
 [UC_44_82_07_30.requirements_lock.md]: UC_44_82_07_30.requirements_lock.md
 [FT_92_51_35_07.local_env_link.md]: ../feature_topic/FT_92_51_35_07.local_env_link.md

--- a/doc/use_case/UC_71_59_90_97.generated_entry_script.md
+++ b/doc/use_case/UC_71_59_90_97.generated_entry_script.md
@@ -1,14 +1,14 @@
 ---
 use_case: UC_71_59_90_97
-case_title: generated entry script
+case_title: generated_entry_script
 case_status: TODO
 ---
 
 
 # UC_71_59_90_97.generated_entry_script
 
-It should be possible to generate boilerplate code in [FT_75_87_82_46.entry_script.md][FT_75_87_82_46.entry_script.md]
-to import [FT_87_17_49_36.kernel_copy.md][FT_87_17_49_36.kernel_copy.md].
+It should be possible to generate boilerplate code in [entry_script][FT_75_87_82_46.entry_script.md]
+to import [kernel_copy][FT_87_17_49_36.kernel_copy.md].
 
 There should be options:
 
@@ -23,7 +23,7 @@ There should be options:
 
 *   `entry_kernel`
 
-    This is the most flexible approach by starting via [FT_87_17_49_36.kernel_copy.md][FT_87_17_49_36.kernel_copy.md].
+    This is the most flexible approach by starting via [kernel_copy][FT_87_17_49_36.kernel_copy.md].
 
 [FT_75_87_82_46.entry_script.md]: ../feature_topic/FT_75_87_82_46.entry_script.md
 [FT_87_17_49_36.kernel_copy.md]: ../feature_topic/FT_87_17_49_36.kernel_copy.md

--- a/doc/use_case/UC_78_58_06_54.no_stray_packages.md
+++ b/doc/use_case/UC_78_58_06_54.no_stray_packages.md
@@ -1,6 +1,6 @@
 ---
 use_case: UC_78_58_06_54
-case_title: no stray packages
+case_title: no_stray_packages
 case_status: DONE
 ---
 

--- a/doc/use_case/UC_81_50_97_17.do_not_reuse_logger.md
+++ b/doc/use_case/UC_81_50_97_17.do_not_reuse_logger.md
@@ -1,13 +1,13 @@
 ---
 use_case: UC_81_50_97_17
-case_title: do not reuse logger
+case_title: do_not_reuse_logger
 case_status: TEST
 ---
 
 
 # UC_81_50_97_17.do_not_reuse_logger
 
-A started app (see [FT_05_08_64_67.start_app.md][FT_05_08_64_67.start_app.md]) cannot
+A started app (see [start_app][FT_05_08_64_67.start_app.md]) cannot
 reuse the existing logger set up by the primer (or possibly re-configure it).
 
 TODO: Shell we disable configuring loggers for `EntryFunc.func_start_app`?

--- a/doc/use_case/UC_88_09_19_74.no_installation_outside_venv.md
+++ b/doc/use_case/UC_88_09_19_74.no_installation_outside_venv.md
@@ -1,6 +1,6 @@
 ---
 use_case: UC_88_09_19_74
-case_title: no installation outside `venv`
+case_title: no_installation_outside_venv
 case_status: TODO
 ---
 
@@ -12,9 +12,9 @@ There is no (known) use case for `protoprimer` to be installed outside a `venv`.
 In fact, the entire bootstrap process with all states imply `venv` usage.
 
 Allowing it to be installed outside `venv` would also lead to come complications
-of detecting `leap_primer` configuration (see [FT_89_41_35_82.conf_leap.md][FT_89_41_35_82.conf_leap.md]) -
+of detecting `leap_primer` configuration (see [conf_leap][FT_89_41_35_82.conf_leap.md]) -
 its location is assumed to be in the same directory with stand-alone
-[FT_90_65_67_62.proto_code.md][FT_90_65_67_62.proto_code.md] (not in the package installation directory).
+[proto_code][FT_90_65_67_62.proto_code.md] (not in the package installation directory).
 
 [FT_90_65_67_62.proto_code.md]: ../feature_topic/FT_90_65_67_62.proto_code.md
 [FT_89_41_35_82.conf_leap.md]: ../feature_topic/FT_89_41_35_82.conf_leap.md

--- a/doc/use_case/UC_90_98_17_93.run_under_venv.md
+++ b/doc/use_case/UC_90_98_17_93.run_under_venv.md
@@ -1,6 +1,6 @@
 ---
 use_case: UC_90_98_17_93
-case_title: run under venv
+case_title: run_under_venv
 case_status: DONE
 ---
 
@@ -20,6 +20,6 @@ When `venv` and path to `proto_code` was not specified,
 switch out of this `venv` (escape) to the python (`sys.base_prefix`) used by this `venv`.
 
 Actually, it should isolate itself not only from `venv` but from any deployed non-standard packages.
-See [FT_28_25_63_06.isolated_python.md][FT_28_25_63_06.isolated_python.md].
+See [isolated_python][FT_28_25_63_06.isolated_python.md].
 
 [FT_28_25_63_06.isolated_python.md]: ../feature_topic/FT_28_25_63_06.isolated_python.md

--- a/doc/use_case/UC_94_67_42_40.support_monorepo.md
+++ b/doc/use_case/UC_94_67_42_40.support_monorepo.md
@@ -1,6 +1,6 @@
 ---
 use_case: UC_94_67_42_40
-case_title: support monorepo
+case_title: support_monorepo
 case_status: TODO
 ---
 
@@ -9,7 +9,7 @@ case_status: TODO
 
 A [monorepo][monorepo_wiki] is a repo with multiple related projects (with their own config).
 
-See: [FT_32_61_30_43.monorepo_support.md][FT_32_61_30_43.monorepo_support.md]
+See: [monorepo_support][FT_32_61_30_43.monorepo_support.md]
 
 [monorepo_wiki]: https://en.wikipedia.org/wiki/Monorepo
 [FT_32_61_30_43.monorepo_support.md]: ../feature_topic/FT_32_61_30_43.monorepo_support.md

--- a/src/local_doc/test/test_local_doc/doc_verifier.py
+++ b/src/local_doc/test/test_local_doc/doc_verifier.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
+
+_doc_id_filename_re = re.compile(r"^[A-Za-z]+(_\d+)+\.[^.]+\.md$")
+_link_def_re = re.compile(r"^\[([^\]]+)\]:\s+(\S+)")
+_inline_link_re = re.compile(r"\[([^\]]+)\]\[([^\]]+)\]")
 
 
 def parse_frontmatter(file_path: Path) -> dict[str, str]:
@@ -48,6 +53,53 @@ def assert_h1_title_matches_filename(file_path: Path) -> None:
     expected_h1 = f"# {file_path.stem}"
     file_lines = file_path.read_text().splitlines()
     assert any(line.strip() == expected_h1 for line in file_lines)
+
+
+def assert_title_slug_matches_filename(file_path: Path, title_key: str) -> None:
+    front_matter = parse_frontmatter(file_path)
+    title_value = front_matter.get(title_key, "")
+    name_slug = file_path.stem.split(".", 1)[-1]
+    assert title_value == name_slug
+
+
+def assert_doc_id_link_labels_match_basename(file_path: Path) -> None:
+    mismatches: list[tuple[str, str]] = []
+    for line in file_path.read_text().splitlines():
+        line_match = _link_def_re.match(line.strip())
+        if not line_match:
+            continue
+        label, target = line_match.group(1), line_match.group(2)
+        basename = Path(target).name
+        if not _doc_id_filename_re.match(basename):
+            continue
+        if label != basename:
+            mismatches.append((label, basename))
+    if mismatches:
+        raise AssertionError(f"Link label != basename: {mismatches}")
+
+
+def assert_doc_id_link_captions_are_slug(file_path: Path) -> None:
+    violations: list[tuple[str, str, str]] = []
+    for line in file_path.read_text().splitlines():
+        stripped_line = line.strip()
+        if _link_def_re.match(stripped_line):
+            continue
+        for inline_match in _inline_link_re.finditer(stripped_line):
+            caption, ref_id = inline_match.group(1), inline_match.group(2)
+            basename = Path(ref_id).name
+            if not _doc_id_filename_re.match(basename):
+                continue
+            expected_slug = Path(basename).stem.split(".", 1)[-1]
+            if caption != expected_slug:
+                violations.append(
+                    (
+                        caption,
+                        ref_id,
+                        expected_slug,
+                    )
+                )
+    if violations:
+        raise AssertionError(f"Link caption should be slug: {violations}")
 
 
 def assert_title_tokens_in_title(file_path: Path, title_key: str) -> None:

--- a/src/local_doc/test/test_local_doc/test_feature_topic.py
+++ b/src/local_doc/test/test_local_doc/test_feature_topic.py
@@ -7,10 +7,13 @@ import pytest
 from local_doc.common_func import list_doc_files
 from local_test.repo_tree import change_to_known_repo_path
 from test_local_doc.doc_verifier import (
+    assert_doc_id_link_captions_are_slug,
+    assert_doc_id_link_labels_match_basename,
     assert_h1_title_matches_filename,
     assert_has_yaml_header,
     assert_id_matches_filename,
     assert_status_valid,
+    assert_title_slug_matches_filename,
     assert_title_tokens_in_title,
 )
 
@@ -61,5 +64,32 @@ def test_topic_title_tokens_in_title(file_path: Path) -> None:
     _ft_files,
     ids=[doc_file.name for doc_file in _ft_files],
 )
+def test_topic_title_slug_matches_filename(file_path: Path) -> None:
+    assert_title_slug_matches_filename(file_path, "topic_title")
+
+
+@pytest.mark.parametrize(
+    "file_path",
+    _ft_files,
+    ids=[doc_file.name for doc_file in _ft_files],
+)
 def test_h1_title_matches_filename(file_path: Path) -> None:
     assert_h1_title_matches_filename(file_path)
+
+
+@pytest.mark.parametrize(
+    "file_path",
+    _ft_files,
+    ids=[doc_file.name for doc_file in _ft_files],
+)
+def test_doc_id_link_labels_match_basename(file_path: Path) -> None:
+    assert_doc_id_link_labels_match_basename(file_path)
+
+
+@pytest.mark.parametrize(
+    "file_path",
+    _ft_files,
+    ids=[doc_file.name for doc_file in _ft_files],
+)
+def test_doc_id_link_captions_are_slug(file_path: Path) -> None:
+    assert_doc_id_link_captions_are_slug(file_path)

--- a/src/local_doc/test/test_local_doc/test_use_case.py
+++ b/src/local_doc/test/test_local_doc/test_use_case.py
@@ -7,10 +7,13 @@ import pytest
 from local_doc.common_func import list_doc_files
 from local_test.repo_tree import change_to_known_repo_path
 from test_local_doc.doc_verifier import (
+    assert_doc_id_link_captions_are_slug,
+    assert_doc_id_link_labels_match_basename,
     assert_h1_title_matches_filename,
     assert_has_yaml_header,
     assert_id_matches_filename,
     assert_status_valid,
+    assert_title_slug_matches_filename,
     assert_title_tokens_in_title,
 )
 
@@ -61,5 +64,32 @@ def test_case_title_tokens_in_title(file_path: Path) -> None:
     _uc_files,
     ids=[doc_file.name for doc_file in _uc_files],
 )
+def test_case_title_slug_matches_filename(file_path: Path) -> None:
+    assert_title_slug_matches_filename(file_path, "case_title")
+
+
+@pytest.mark.parametrize(
+    "file_path",
+    _uc_files,
+    ids=[doc_file.name for doc_file in _uc_files],
+)
 def test_h1_title_matches_filename(file_path: Path) -> None:
     assert_h1_title_matches_filename(file_path)
+
+
+@pytest.mark.parametrize(
+    "file_path",
+    _uc_files,
+    ids=[doc_file.name for doc_file in _uc_files],
+)
+def test_doc_id_link_labels_match_basename(file_path: Path) -> None:
+    assert_doc_id_link_labels_match_basename(file_path)
+
+
+@pytest.mark.parametrize(
+    "file_path",
+    _uc_files,
+    ids=[doc_file.name for doc_file in _uc_files],
+)
+def test_doc_id_link_captions_are_slug(file_path: Path) -> None:
+    assert_doc_id_link_captions_are_slug(file_path)


### PR DESCRIPTION
*   Render page titles without prefixes.
*   Preserve prefixes in `reference.html`.
*   Normalize titles to match `some_name` in `XX_00_00_00_00.some_name.md`.

*   Ensure link definitions:

    `[XX_00_00_00_00.some_name.md]: path/to/XX_00_00_00_00.some_name.md` use file basename

*   Ensure link references:

    `[some_name][XX_00_00_00_00.some_name.md]` use `some_name`
